### PR TITLE
feat(bazel): enable Go metadata gen

### DIFF
--- a/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.gapic_api.mustache
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.gapic_api.mustache
@@ -117,6 +117,7 @@ go_gapic_library(
     grpc_service_config = {{grpc_service_config}},
     importpath = "{{go_gapic_importpath}}",
     service_yaml = "{{service_yaml}}",
+    metadata = True,
     deps = [
         ":{{name}}_go_proto",{{go_gapic_deps}}
     ],
@@ -135,6 +136,7 @@ go_gapic_assembly_pkg(
     deps = [
         ":{{name}}_go_gapic",
         ":{{name}}_go_gapic_srcjar-test.srcjar",
+        ":{{name}}_go_gapic_srcjar-metadata.srcjar",
         ":{{name}}_go_proto",
     ],
 )

--- a/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.baseline
+++ b/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.baseline
@@ -124,6 +124,7 @@ go_gapic_library(
     grpc_service_config = "library_example_grpc_service_config.json",
     importpath = "cloud.google.com/go/example/library/apiv1;library",
     service_yaml = "//google/example/library:library_example_v1.yaml",
+    metadata = True,
     deps = [
         ":library_go_proto",
         "//google/api:httpbody_go_proto",
@@ -143,6 +144,7 @@ go_gapic_assembly_pkg(
     deps = [
         ":library_go_gapic",
         ":library_go_gapic_srcjar-test.srcjar",
+        ":library_go_gapic_srcjar-metadata.srcjar",
         ":library_go_proto",
     ],
 )


### PR DESCRIPTION
Enables generation of `GapicMetadata` and inclusion of the `gapic_metadata.json` with the assembled archive.

Fixes #10 