### PR TITLE
fix: properly support spaces in string values

### DIFF
--- a/bazel/src/main/java/com/google/api/codegen/bazel/Buildozer.java
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/Buildozer.java
@@ -82,6 +82,7 @@ public class Buildozer {
       if (value.equals("(missing)")) {
         return null;
       }
+      // if value has spaces, `buildozer print` will return it in quotes. Remove the quotes
       if (value.charAt(0) == '"' && value.charAt(value.length() - 1) == '"') {
         value = value.substring(1, value.length() - 1);
       }
@@ -91,50 +92,38 @@ public class Buildozer {
     }
   }
 
-  // Set the value to the given attribute of the given target. Apply changes
-  // immediately.
-  public void setAttribute(Path bazelBuildFile, String target, String attribute, String value)
-      throws IOException {
-    final String escapedValue = value.replace(" ", "\\ ");
-    execute(bazelBuildFile, String.format("set %s \"%s\"", attribute, escapedValue), target);
-  }
-
-  // Remove the given attribute of the given target. Apply changes immediately.
-  public void removeAttribute(Path bazelBuildFile, String target, String attribute)
-      throws IOException {
-    execute(bazelBuildFile, String.format("remove %s", attribute), target);
-  }
-
-  // Add the value to the given list attribute of the given target. Apply changes
-  // immediately.
-  public void addAttribute(Path bazelBuildFile, String target, String attribute, String value)
-      throws IOException {
-    final String escapedValue = value.replace(" ", "\\ ");
-    execute(bazelBuildFile, String.format("add %s \"%s\"", attribute, escapedValue), target);
-  }
-
   // Set the value to the given attribute of the given target.
   // The changes will be applied when the whole batch is committed with .commit().
   public void batchSetAttribute(Path bazelBuildFile, String target, String attribute, String value)
       throws IOException {
-    final String escapedValue = value.replace(" ", "\\ ");
     batch.add(
-        String.format("set %s \"%s\"|%s:%s", attribute, escapedValue, bazelBuildFile.toString(), target));
+        String.format(
+            "set %s \"%s\"|%s:%s",
+            attribute,
+            value.replace(" ", "\\ "),
+            bazelBuildFile.toString(), target));
   }
 
   // Remove the given attribute of the given target. Apply changes immediately.
   public void batchRemoveAttribute(Path bazelBuildFile, String target, String attribute)
       throws IOException {
-    batch.add(String.format("remove %s|%s:%s", attribute, bazelBuildFile.toString(), target));
+    batch.add(
+        String.format("remove %s|%s:%s",
+            attribute,
+            bazelBuildFile.toString(),
+            target));
   }
 
   // Add the value to the given list attribute of the given target.
   // The changes will be applied when the whole batch is committed with .commit().
   public void batchAddAttribute(Path bazelBuildFile, String target, String attribute, String value)
       throws IOException {
-    final String escapedValue = value.replace(" ", "\\ ");
     batch.add(
-        String.format("add %s \"%s\"|%s:%s", attribute, escapedValue, bazelBuildFile.toString(), target));
+        String.format(
+            "add %s \"%s\"|%s:%s",
+            attribute,
+            value.replace(" ", "\\ "),
+            bazelBuildFile.toString(), target));
   }
 
   // Make all changes that are waiting in the batch.

--- a/bazel/src/main/java/com/google/api/codegen/bazel/Buildozer.java
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/Buildozer.java
@@ -82,6 +82,9 @@ public class Buildozer {
       if (value.equals("(missing)")) {
         return null;
       }
+      if (value.charAt(0) == '"' && value.charAt(value.length() - 1) == '"') {
+        value = value.substring(1, value.length() - 1);
+      }
       return value;
     } catch (IndexOutOfBoundsException ignored) {
       return null;
@@ -92,7 +95,8 @@ public class Buildozer {
   // immediately.
   public void setAttribute(Path bazelBuildFile, String target, String attribute, String value)
       throws IOException {
-    execute(bazelBuildFile, String.format("set %s \"%s\"", attribute, value), target);
+    final String escapedValue = value.replace(" ", "\\ ");
+    execute(bazelBuildFile, String.format("set %s \"%s\"", attribute, escapedValue), target);
   }
 
   // Remove the given attribute of the given target. Apply changes immediately.
@@ -105,15 +109,17 @@ public class Buildozer {
   // immediately.
   public void addAttribute(Path bazelBuildFile, String target, String attribute, String value)
       throws IOException {
-    execute(bazelBuildFile, String.format("add %s \"%s\"", attribute, value), target);
+    final String escapedValue = value.replace(" ", "\\ ");
+    execute(bazelBuildFile, String.format("add %s \"%s\"", attribute, escapedValue), target);
   }
 
   // Set the value to the given attribute of the given target.
   // The changes will be applied when the whole batch is committed with .commit().
   public void batchSetAttribute(Path bazelBuildFile, String target, String attribute, String value)
       throws IOException {
+    final String escapedValue = value.replace(" ", "\\ ");
     batch.add(
-        String.format("set %s \"%s\"|%s:%s", attribute, value, bazelBuildFile.toString(), target));
+        String.format("set %s \"%s\"|%s:%s", attribute, escapedValue, bazelBuildFile.toString(), target));
   }
 
   // Remove the given attribute of the given target. Apply changes immediately.
@@ -126,8 +132,9 @@ public class Buildozer {
   // The changes will be applied when the whole batch is committed with .commit().
   public void batchAddAttribute(Path bazelBuildFile, String target, String attribute, String value)
       throws IOException {
+    final String escapedValue = value.replace(" ", "\\ ");
     batch.add(
-        String.format("add %s \"%s\"|%s:%s", attribute, value, bazelBuildFile.toString(), target));
+        String.format("add %s \"%s\"|%s:%s", attribute, escapedValue, bazelBuildFile.toString(), target));
   }
 
   // Make all changes that are waiting in the batch.

--- a/bazel/src/test/java/com/google/api/codegen/bazel/BuildFileGeneratorTest.java
+++ b/bazel/src/test/java/com/google/api/codegen/bazel/BuildFileGeneratorTest.java
@@ -192,15 +192,17 @@ public class BuildFileGeneratorTest {
         "[value1 value2]", buildozer.getAttribute(buildBazel, "rule2", "list_attr"));
 
     // Set some attributes and get the result
-    buildozer.setAttribute(buildBazel, "rule1", "attr", "new_attr_value");
-    buildozer.addAttribute(buildBazel, "rule2", "list_attr", "value3");
+    buildozer.batchSetAttribute(buildBazel, "rule1", "attr", "new_attr_value");
+    buildozer.batchAddAttribute(buildBazel, "rule2", "list_attr", "value3");
+    buildozer.commit();
     Assert.assertEquals("new_attr_value", buildozer.getAttribute(buildBazel, "rule1", "attr"));
     Assert.assertEquals(
         "[value1 value2 value3]", buildozer.getAttribute(buildBazel, "rule2", "list_attr"));
 
     // Remove attribute
     Assert.assertEquals("remove_a", buildozer.getAttribute(buildBazel, "rule1", "to_be_removed_a"));
-    buildozer.removeAttribute(buildBazel, "rule1", "to_be_removed_a");
+    buildozer.batchRemoveAttribute(buildBazel, "rule1", "to_be_removed_a");
+    buildozer.commit();
     Assert.assertEquals(null, buildozer.getAttribute(buildBazel, "rule1", "to_be_removed_a"));
 
     // Test batch operations

--- a/bazel/src/test/java/com/google/api/codegen/bazel/BuildFileGeneratorTest.java
+++ b/bazel/src/test/java/com/google/api/codegen/bazel/BuildFileGeneratorTest.java
@@ -119,6 +119,8 @@ public class BuildFileGeneratorTest {
         "renamed_csharp_rule");
     buildozer.batchSetAttribute(
         gapicBuildFilePath, "google-cloud-example-library-v1-java", "name", "renamed_java_rule");
+    buildozer.batchSetAttribute(
+        gapicBuildFilePath, "library_ruby_gapic", "ruby_cloud_title", "Title with spaces");
 
     // The following values should NOT be preserved:
     buildozer.batchSetAttribute(
@@ -147,6 +149,10 @@ public class BuildFileGeneratorTest {
     Assert.assertEquals(
         "renamed_java_rule",
         buildozer.getAttribute(gapicBuildFilePath, "%java_gapic_assembly_gradle_pkg", "name"));
+    Assert.assertEquals(
+        "Title with spaces",
+        buildozer.getAttribute(gapicBuildFilePath, "%ruby_cloud_gapic_library", "ruby_cloud_title"));
+
     // Check that grpc_service_config value is not preserved:
     Assert.assertEquals(
         "library_example_grpc_service_config.json",


### PR DESCRIPTION
Some values can have spaces in them. For such strings, `buildozer print` returns a `"string in quotes"`, but to write them back, we `"must\ quote\ spaces"`.  Weird it is.