### PR TITLE
[build_gen] fix(bazel): Default to PHP microgenerator rules

### DIFF
--- a/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.gapic_api.mustache
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.gapic_api.mustache
@@ -169,10 +169,10 @@ py_gapic_assembly_pkg(
 ##############################################################################
 load(
     "@com_google_googleapis_imports//:imports.bzl",
-    "php_gapic_assembly_pkg",
-    "php_gapic_library",
-    "php_grpc_library",
-    "php_proto_library",
+    php_gapic_assembly_pkg = "php_gapic_assembly_pkg2",
+    php_gapic_library = "php_gapic_library2",
+    php_grpc_library = "php_grpc_library2",
+    php_proto_library = "php_proto_library2",
 )
 
 php_proto_library(
@@ -188,10 +188,8 @@ php_grpc_library(
 
 php_gapic_library(
     name = "{{name}}_php_gapic",
-    src = ":{{name}}_proto_with_info",
-    gapic_yaml = "{{gapic_yaml}}",
+    srcs = [":{{name}}_proto_with_info"],
     grpc_service_config = {{grpc_service_config}},
-    package = "{{package}}",
     service_yaml = "{{service_yaml}}",
     deps = [
         ":{{name}}_php_grpc",

--- a/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
@@ -76,7 +76,6 @@ class BazelBuildFileView {
           "\"" + convertPathToLabel(bp.getProtoPackage(), bp.getServiceConfigJsonPath()) + "\"");
     }
 
-    tokens.put("gapic_yaml", convertPathToLabel(bp.getProtoPackage(), bp.getGapicYamlPath()));
     tokens.put("service_yaml", convertPathToLabel(bp.getProtoPackage(), bp.getServiceYamlPath()));
 
     Set<String> javaTests = new TreeSet<>();
@@ -209,7 +208,7 @@ class BazelBuildFileView {
   private Set<String> mapJavaGapicTestDeps(Set<String> protoImports) {
     Set<String> javaImports = new TreeSet<>();
     for (String protoImport : protoImports) {
-      if (protoImport.endsWith(":iam_policy_proto") 
+      if (protoImport.endsWith(":iam_policy_proto")
           || protoImport.endsWith(":policy_proto")
           || protoImport.endsWith(":options_proto")) {
         javaImports.add(replaceLabelName(protoImport, ":iam_java_grpc"));

--- a/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.baseline
+++ b/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.baseline
@@ -177,10 +177,10 @@ py_gapic_assembly_pkg(
 ##############################################################################
 load(
     "@com_google_googleapis_imports//:imports.bzl",
-    "php_gapic_assembly_pkg",
-    "php_gapic_library",
-    "php_grpc_library",
-    "php_proto_library",
+    php_gapic_assembly_pkg = "php_gapic_assembly_pkg2",
+    php_gapic_library = "php_gapic_library2",
+    php_grpc_library = "php_grpc_library2",
+    php_proto_library = "php_proto_library2",
 )
 
 php_proto_library(
@@ -196,10 +196,8 @@ php_grpc_library(
 
 php_gapic_library(
     name = "library_php_gapic",
-    src = ":library_proto_with_info",
-    gapic_yaml = "library_example_gapic.yaml",
+    srcs = [":library_proto_with_info"],
     grpc_service_config = "library_example_grpc_service_config.json",
-    package = "google.example.library.v1",
     service_yaml = "//google/example/library:library_example_v1.yaml",
     deps = [
         ":library_php_grpc",

--- a/bazel/src/test/data/googleapis/google/example/library/v1legacy/BUILD.bazel.baseline
+++ b/bazel/src/test/data/googleapis/google/example/library/v1legacy/BUILD.bazel.baseline
@@ -177,10 +177,10 @@ py_gapic_assembly_pkg(
 ##############################################################################
 load(
     "@com_google_googleapis_imports//:imports.bzl",
-    "php_gapic_assembly_pkg",
-    "php_gapic_library",
-    "php_grpc_library",
-    "php_proto_library",
+    php_gapic_assembly_pkg = "php_gapic_assembly_pkg2",
+    php_gapic_library = "php_gapic_library2",
+    php_grpc_library = "php_grpc_library2",
+    php_proto_library = "php_proto_library2",
 )
 
 php_proto_library(
@@ -196,10 +196,8 @@ php_grpc_library(
 
 php_gapic_library(
     name = "library_php_gapic",
-    src = ":library_proto_with_info",
-    gapic_yaml = "library_example_gapic.yaml",
+    srcs = [":library_proto_with_info"],
     grpc_service_config = "library_example_grpc_service_config.json",
-    package = "google.example.library.v1",
     service_yaml = "//google/example/library:library_example_v1.yaml",
     deps = [
         ":library_php_grpc",


### PR DESCRIPTION
Sticking with the "2"-suffixed name for the time being, until more libraries are migrated.