### PR TITLE
[build_gen] fix(monolith): gate GAPIC build_gen on service.yaml or grpc_service_config.json

### DIFF
--- a/bazel/src/main/java/com/google/api/codegen/bazel/ApisVisitor.java
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/ApisVisitor.java
@@ -137,7 +137,9 @@ class ApisVisitor extends SimpleFileVisitor<Path> {
     BazelBuildFileTemplate template = null;
     String tmplType = "";
     if (bp.getProtoPackage() != null) {
-      if (bp.getGapicYamlPath() != null) {
+      boolean isGapicLibrary =
+          bp.getServiceYamlPath() != null || bp.getServiceConfigJsonPath() != null;
+      if (isGapicLibrary) {
         bp.injectFieldsFromTopLevel();
         template = this.gapicApiTempl;
         tmplType = "GAPIC_VERSIONED";

--- a/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
@@ -62,7 +62,9 @@ class BazelBuildFileView {
     tokens.put("go_proto_importpath", bp.getLangProtoPackages().get("go").split(";")[0]);
     tokens.put("go_proto_deps", joinSetWithIndentation(mapGoProtoDeps(actualImports)));
 
-    if (bp.getGapicYamlPath() == null) {
+    boolean isGapicLibrary =
+        bp.getServiceYamlPath() != null || bp.getServiceConfigJsonPath() != null;
+    if (!isGapicLibrary) {
       return;
     }
 
@@ -209,7 +211,7 @@ class BazelBuildFileView {
   private Set<String> mapJavaGapicTestDeps(Set<String> protoImports) {
     Set<String> javaImports = new TreeSet<>();
     for (String protoImport : protoImports) {
-      if (protoImport.endsWith(":iam_policy_proto") 
+      if (protoImport.endsWith(":iam_policy_proto")
           || protoImport.endsWith(":policy_proto")
           || protoImport.endsWith(":options_proto")) {
         javaImports.add(replaceLabelName(protoImport, ":iam_java_grpc"));


### PR DESCRIPTION
Gates GAPIC-build file generation on the presence of `service.yaml` or `grpc_service_config.json`. APIs who want just the raw, proto-only build file don't need to use these files, so there is no need for them have either alongside their protos.

A cursory search over all protos with the following query string shows that this is a sufficiently-good heuristic.
- `f:third_party/googleapis f:BUILD.bazel "java_proto_library" -"java_gapic_library"`