### PR TITLE
fix: remove gen of protoc-gen-docs-plugin

### DIFF
--- a/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.raw_api.mustache
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.raw_api.mustache
@@ -76,7 +76,6 @@ moved_proto_library(
 
 py_proto_library(
     name = "{{name}}_py_proto",
-    plugin = "@protoc_docs_plugin//:docs_plugin",
     deps = [":{{name}}_moved_proto"],
 )
 


### PR DESCRIPTION
We no longer need to generate the python proto library with the `protoc-gen-docs_plugin`. In fact, it is not up to date with the latest protoc features and creates build failures when it encounters a proto3_optional field.