### PR TITLE
feat(bazel): py_gapic_library for non-service protos

### DIFF
--- a/bazel/src/test/data/googleapis/google/example/library/type/BUILD.bazel.baseline
+++ b/bazel/src/test/data/googleapis/google/example/library/type/BUILD.bazel.baseline
@@ -9,12 +9,14 @@ package(default_visibility = ["//visibility:public"])
 load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
-    name = "{{name}}_proto",
+    name = "types_proto",
     srcs = [
-        {{proto_srcs}}
+        "library_types.proto",
     ],
     deps = [
-        {{proto_deps}}
+        "//google/api:annotations_proto",
+        "//google/api:field_behavior_proto",
+        "//google/api:resource_proto",
     ],
 )
 
@@ -28,14 +30,14 @@ load(
 )
 
 java_proto_library(
-    name = "{{name}}_java_proto",
-    deps = [":{{name}}_proto"],
+    name = "types_java_proto",
+    deps = [":types_proto"],
 )
 
 java_grpc_library(
-    name = "{{name}}_java_grpc",
-    srcs = [":{{name}}_proto"],
-    deps = [":{{name}}_java_proto"],
+    name = "types_java_grpc",
+    srcs = [":types_proto"],
+    deps = [":types_java_proto"],
 )
 
 ##############################################################################
@@ -47,12 +49,12 @@ load(
 )
 
 go_proto_library(
-    name = "{{name}}_go_proto",
+    name = "types_go_proto",
     compilers = ["@io_bazel_rules_go//proto:go_grpc"],
-    importpath = "{{go_proto_importpath}}",
-    protos = [":{{name}}_proto"],
+    importpath = "google.golang.org/genproto/googleapis/example/library/types",
+    protos = [":types_proto"],
     deps = [
-        {{go_proto_deps}}
+        "//google/api:annotations_go_proto",
     ],
 )
 
@@ -66,15 +68,15 @@ load(
 )
 
 py_gapic_library(
-    name = "{{name}}_py_gapic",
-    srcs = [":{{name}}_proto"],
+    name = "types_py_gapic",
+    srcs = [":types_proto"],
 )
 
 # Open Source Packages
 py_gapic_assembly_pkg(
-    name = "{{assembly_name}}-{{version}}-py",
+    name = "types-{{version}}-py",
     deps = [
-        ":{{name}}_py_gapic",
+        ":types_py_gapic",
     ],
 )
 
@@ -88,14 +90,14 @@ load(
 )
 
 php_proto_library(
-    name = "{{name}}_php_proto",
-    deps = [":{{name}}_proto"],
+    name = "types_php_proto",
+    deps = [":types_proto"],
 )
 
 php_grpc_library(
-    name = "{{name}}_php_grpc",
-    srcs = [":{{name}}_proto"],
-    deps = [":{{name}}_php_proto"],
+    name = "types_php_grpc",
+    srcs = [":types_proto"],
+    deps = [":types_php_proto"],
 )
 
 ##############################################################################
@@ -118,14 +120,14 @@ load(
 )
 
 ruby_proto_library(
-    name = "{{name}}_ruby_proto",
-    deps = [":{{name}}_proto"],
+    name = "types_ruby_proto",
+    deps = [":types_proto"],
 )
 
 ruby_grpc_library(
-    name = "{{name}}_ruby_grpc",
-    srcs = [":{{name}}_proto"],
-    deps = [":{{name}}_ruby_proto"],
+    name = "types_ruby_grpc",
+    srcs = [":types_proto"],
+    deps = [":types_ruby_proto"],
 )
 
 ##############################################################################
@@ -138,14 +140,14 @@ load(
 )
 
 csharp_proto_library(
-    name = "{{name}}_csharp_proto",
-    deps = [":{{name}}_proto"],
+    name = "types_csharp_proto",
+    deps = [":types_proto"],
 )
 
 csharp_grpc_library(
-    name = "{{name}}_csharp_grpc",
-    srcs = [":{{name}}_proto"],
-    deps = [":{{name}}_csharp_proto"],
+    name = "types_csharp_grpc",
+    srcs = [":types_proto"],
+    deps = [":types_csharp_proto"],
 )
 
 ##############################################################################

--- a/bazel/src/test/data/googleapis/google/example/library/type/library_types.proto
+++ b/bazel/src/test/data/googleapis/google/example/library/type/library_types.proto
@@ -1,0 +1,46 @@
+// Copyright 2019 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package google.example.library.types;
+
+import "google/api/annotations.proto";
+import "google/api/field_behavior.proto";
+import "google/api/resource.proto";
+
+option go_package = "google.golang.org/genproto/googleapis/example/library/types;library";
+option java_multiple_files = true;
+option java_outer_classname = "LibraryTypesProto";
+option java_package = "com.google.example.library.types";
+
+// A Shelf contains a collection of books with a theme.
+message Shelf {
+  option (google.api.resource) = {
+    type: "library-example.googleapis.com/Shelf",
+    pattern: "shelves/{shelf_id}"
+  };
+  // The resource name of the shelf.
+  // Shelf names have the form `shelves/{shelf_id}`.
+  // The name is ignored when creating a shelf.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type =
+        "library-example.googleapis.com/Shelf"
+  ];
+
+  // The theme of the shelf
+  string theme = 2;
+}

--- a/bazel/src/test/java/com/google/api/codegen/bazel/BuildFileGeneratorTest.java
+++ b/bazel/src/test/java/com/google/api/codegen/bazel/BuildFileGeneratorTest.java
@@ -38,13 +38,17 @@ public class BuildFileGeneratorTest {
     Path fileBodyPathPrefix = Paths.get(PATH_PREFIX, SRC_DIR, "google", "example", "library");
     String gapicBuildFilePath =
         Paths.get(fileBodyPathPrefix.toString(), "v1", "BUILD.bazel").toString();
-    String rawBuildFilePath = Paths.get(fileBodyPathPrefix.toString(), "BUILD.bazel").toString();
+    String rawBuildFilePath = Paths.get(fileBodyPathPrefix.toString(), "type", "BUILD.bazel").toString();
+    System.out.println(fw.files.get(rawBuildFilePath));
+    String rootBuildFilePath = Paths.get(fileBodyPathPrefix.toString(), "BUILD.bazel").toString();
 
-    Assert.assertEquals(3, fw.files.size());
+    Assert.assertEquals(4, fw.files.size());
     Assert.assertEquals(
         ApisVisitor.readFile(gapicBuildFilePath + ".baseline"), fw.files.get(gapicBuildFilePath));
     Assert.assertEquals(
         ApisVisitor.readFile(rawBuildFilePath + ".baseline"), fw.files.get(rawBuildFilePath));
+    Assert.assertEquals(
+        ApisVisitor.readFile(rootBuildFilePath + ".baseline"), fw.files.get(rootBuildFilePath));
   }
 
   @Test
@@ -58,13 +62,13 @@ public class BuildFileGeneratorTest {
     Path fileBodyPathPrefix = Paths.get(PATH_PREFIX, SRC_DIR, "google", "example", "library");
     String gapicBuildFilePath =
         Paths.get(fileBodyPathPrefix.toString(), "v1legacy", "BUILD.bazel").toString();
-    String rawBuildFilePath = Paths.get(fileBodyPathPrefix.toString(), "BUILD.bazel").toString();
+    String rootBuildFilePath = Paths.get(fileBodyPathPrefix.toString(), "BUILD.bazel").toString();
 
-    Assert.assertEquals(3, fw.files.size());
+    Assert.assertEquals(4, fw.files.size());
     Assert.assertEquals(
         ApisVisitor.readFile(gapicBuildFilePath + ".baseline"), fw.files.get(gapicBuildFilePath));
     Assert.assertEquals(
-        ApisVisitor.readFile(rawBuildFilePath + ".baseline"), fw.files.get(rawBuildFilePath));
+        ApisVisitor.readFile(rootBuildFilePath + ".baseline"), fw.files.get(rootBuildFilePath));
   }
 
   @Test
@@ -91,14 +95,14 @@ public class BuildFileGeneratorTest {
     Path fileBodyPathPrefix =
         Paths.get(copiedGoogleapis.toString(), "google", "example", "library");
     Path gapicBuildFilePath = Paths.get(fileBodyPathPrefix.toString(), "v1", "BUILD.bazel");
-    String rawBuildFilePath = Paths.get(fileBodyPathPrefix.toString(), "BUILD.bazel").toString();
+    String rootBuildFilePath = Paths.get(fileBodyPathPrefix.toString(), "BUILD.bazel").toString();
 
     Assert.assertEquals(
         ApisVisitor.readFile(gapicBuildFilePath.toString() + ".baseline"),
         ApisVisitor.readFile(gapicBuildFilePath.toString()));
     Assert.assertEquals(
-        ApisVisitor.readFile(rawBuildFilePath + ".baseline"),
-        ApisVisitor.readFile(rawBuildFilePath));
+        ApisVisitor.readFile(rootBuildFilePath + ".baseline"),
+        ApisVisitor.readFile(rootBuildFilePath));
 
     // Now change some values in google/example/library/v1/BUILD.bazel
     Buildozer.setBinaryPath(buildozerPath);
@@ -170,8 +174,8 @@ public class BuildFileGeneratorTest {
         ApisVisitor.readFile(gapicBuildFilePath.toString() + ".baseline"),
         ApisVisitor.readFile(gapicBuildFilePath.toString()));
     Assert.assertEquals(
-        ApisVisitor.readFile(rawBuildFilePath + ".baseline"),
-        ApisVisitor.readFile(rawBuildFilePath));
+        ApisVisitor.readFile(rootBuildFilePath + ".baseline"),
+        ApisVisitor.readFile(rootBuildFilePath));
   }
 
   @Test


### PR DESCRIPTION
* changes the "raw" template to generate `py_gapic_library` for those non-service protos instead of `moved_proto` `py_proto_library` and `py_grpc_library` in order to get rich descriptors from proto-plus 
* add "raw" template test by adding a non-service proto package `google/example/library/type/library_types.proto`
* refactored use of "raw" name in previous tests referring to the "root" BUILD file

cc: @busunkim96 @parthea 