### PR TITLE
fix(bazel): use None when no service_yaml

### DIFF
--- a/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.gapic_api.mustache
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.gapic_api.mustache
@@ -63,7 +63,7 @@ java_gapic_library(
     name = "{{name}}_java_gapic",
     srcs = [":{{name}}_proto_with_info"],
     grpc_service_config = {{grpc_service_config}},
-    service_yaml = "{{service_yaml}}",
+    service_yaml = {{service_yaml}},
     test_deps = [
         ":{{name}}_java_grpc",{{java_gapic_test_deps}}
     ],
@@ -117,7 +117,7 @@ go_gapic_library(
     srcs = [":{{name}}_proto_with_info"],
     grpc_service_config = {{grpc_service_config}},
     importpath = "{{go_gapic_importpath}}",
-    service_yaml = "{{service_yaml}}",
+    service_yaml = {{service_yaml}},
     metadata = True,
     deps = [
         ":{{name}}_go_proto",{{go_gapic_deps}}
@@ -191,7 +191,7 @@ php_gapic_library(
     name = "{{name}}_php_gapic",
     srcs = [":{{name}}_proto_with_info"],
     grpc_service_config = {{grpc_service_config}},
-    service_yaml = "{{service_yaml}}",
+    service_yaml = {{service_yaml}},
     deps = [
         ":{{name}}_php_grpc",
         ":{{name}}_php_proto",
@@ -224,7 +224,7 @@ nodejs_gapic_library(
     extra_protoc_parameters = ["metadata"],
     grpc_service_config = {{grpc_service_config}},
     package = "{{package}}",
-    service_yaml = "{{service_yaml}}",
+    service_yaml = {{service_yaml}},
     deps = [],
 )
 

--- a/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
@@ -78,7 +78,12 @@ class BazelBuildFileView {
           "\"" + convertPathToLabel(bp.getProtoPackage(), bp.getServiceConfigJsonPath()) + "\"");
     }
 
-    tokens.put("service_yaml", convertPathToLabel(bp.getProtoPackage(), bp.getServiceYamlPath()));
+    String serviceYaml = "None";
+    if (bp.getServiceYamlPath() != null) {
+      // Wrap the label in quotations, because None doesn't need them, so they can't be in the template.
+      serviceYaml = "\""+convertPathToLabel(bp.getProtoPackage(), bp.getServiceYamlPath())+"\"";
+    }
+    tokens.put("service_yaml", serviceYaml);
 
     Set<String> javaTests = new TreeSet<>();
     for (String service : bp.getServices()) {


### PR DESCRIPTION
When there is no `service_yaml` in the directory, we should generate `None` so that we don't generate garbage like `"{{service_yaml}}"` instead. `None` builds, the latter does not.