### PR TITLE
fix(build_gen): use consistent names for open source package

### DIFF
--- a/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.gapic_api.mustache
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.gapic_api.mustache
@@ -81,19 +81,21 @@ java_gapic_test(
 )
 
 # Open Source Packages
+java_gapic_assembly_gradle_pkg_deps = [
+    ":{{name}}_java_gapic",
+    ":{{name}}_java_grpc",
+    ":{{name}}_java_proto",
+    ":{{name}}_proto",
+]
+
 java_gapic_assembly_gradle_pkg(
     name = "{{assembly_name}}-{{version}}-java",
-    deps = [
-        ":{{name}}_java_gapic",
-        ":{{name}}_java_grpc",
-        ":{{name}}_java_proto",
-        ":{{name}}_proto",
-    ],
+    deps = java_gapic_assembly_gradle_pkg_deps,
 )
 
-alias(
+java_gapic_assembly_gradle_pkg(
     name = "google-cloud-{{assembly_name}}-{{version}}-java",
-    actual = ":{{assembly_name}}-{{version}}-go",
+    deps = java_gapic_assembly_gradle_pkg_deps,
     deprecated = "Please use :{{assembly_name}}-{{version}}-java."
 )
 
@@ -138,19 +140,21 @@ go_test(
 )
 
 # Open Source Packages
+go_gapic_assembly_pkg_deps = [
+    ":{{name}}_go_gapic",
+    ":{{name}}_go_gapic_srcjar-test.srcjar",
+    ":{{name}}_go_gapic_srcjar-metadata.srcjar",
+    ":{{name}}_go_proto",
+]
+
 go_gapic_assembly_pkg(
     name = "{{assembly_name}}-{{version}}-go",
-    deps = [
-        ":{{name}}_go_gapic",
-        ":{{name}}_go_gapic_srcjar-test.srcjar",
-        ":{{name}}_go_gapic_srcjar-metadata.srcjar",
-        ":{{name}}_go_proto",
-    ],
+    deps = go_gapic_assembly_pkg_deps,
 )
 
-alias(
+go_gapic_assembly_pkg(
     name = "gapi-cloud-{{assembly_name}}-{{version}}-go",
-    actual = ":{{assembly_name}}-{{version}}-go",
+    deps = go_gapic_assembly_pkg_deps,
     deprecated = "Please use :{{assembly_name}}-{{version}}-go."
 )
 
@@ -211,18 +215,20 @@ php_gapic_library(
 )
 
 # Open Source Packages
+php_gapic_assembly_pkg_deps = [
+    ":{{name}}_php_gapic",
+    ":{{name}}_php_grpc",
+    ":{{name}}_php_proto",
+]
+
 php_gapic_assembly_pkg(
     name = "{{assembly_name}}-{{version}}-php",
-    deps = [
-        ":{{name}}_php_gapic",
-        ":{{name}}_php_grpc",
-        ":{{name}}_php_proto",
-    ],
+    deps = php_gapic_assembly_pkg_deps,
 )
 
-alias(
+php_gapic_assembly_pkg(
     name = "google-cloud-{{assembly_name}}-{{version}}-php",
-    actual = ":{{assembly_name}}-{{version}}-php",
+    deps = php_gapic_assembly_pkg_deps,
     deprecated = "Please use :{{assembly_name}}-{{version}}-php."
 )
 
@@ -290,18 +296,20 @@ ruby_cloud_gapic_library(
 )
 
 # Open Source Packages
+ruby_gapic_assembly_pkg_deps = [
+    ":{{name}}_ruby_gapic",
+    ":{{name}}_ruby_grpc",
+    ":{{name}}_ruby_proto",
+]
+
 ruby_gapic_assembly_pkg(
     name = "{{assembly_name}}-{{version}}-ruby",
-    deps = [
-        ":{{name}}_ruby_gapic",
-        ":{{name}}_ruby_grpc",
-        ":{{name}}_ruby_proto",
-    ],
+    deps = ruby_gapic_assembly_pkg_deps,
 )
 
-alias(
+ruby_gapic_assembly_pkg(
     name = "google-cloud-{{assembly_name}}-{{version}}-ruby",
-    actual = ":{{assembly_name}}-{{version}}-ruby",
+    deps = ruby_gapic_assembly_pkg_deps,
     deprecated = "Please use :{{assembly_name}}-{{version}}-ruby."
 )
 
@@ -339,18 +347,20 @@ csharp_gapic_library(
 )
 
 # Open Source Packages
+csharp_gapic_assembly_pkg_deps = [
+    ":{{name}}_csharp_gapic",
+    ":{{name}}_csharp_grpc",
+    ":{{name}}_csharp_proto",
+]
+
 csharp_gapic_assembly_pkg(
     name = "{{assembly_name}}-{{version}}-csharp",
-    deps = [
-        ":{{name}}_csharp_gapic",
-        ":{{name}}_csharp_grpc",
-        ":{{name}}_csharp_proto",
-    ],
+    deps = csharp_gapic_assembly_pkg_deps,
 )
 
-alias(
+csharp_gapic_assembly_pkg(
     name = "google-cloud-{{assembly_name}}-{{version}}-csharp",
-    actual = ":{{assembly_name}}-{{version}}-csharp",
+    deps = csharp_gapic_assembly_pkg_deps,
     deprecated = "Please use :{{assembly_name}}-{{version}}-csharp."
 )
 

--- a/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.gapic_api.mustache
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.gapic_api.mustache
@@ -82,13 +82,19 @@ java_gapic_test(
 
 # Open Source Packages
 java_gapic_assembly_gradle_pkg(
-    name = "google-cloud-{{assembly_name}}-{{version}}-java",
+    name = "{{assembly_name}}-{{version}}-java",
     deps = [
         ":{{name}}_java_gapic",
         ":{{name}}_java_grpc",
         ":{{name}}_java_proto",
         ":{{name}}_proto",
     ],
+)
+
+alias(
+    name = "google-cloud-{{assembly_name}}-{{version}}-java",
+    actual = ":{{assembly_name}}-{{version}}-go",
+    deprecated = "Please use :{{assembly_name}}-{{version}}-java."
 )
 
 ##############################################################################
@@ -133,13 +139,19 @@ go_test(
 
 # Open Source Packages
 go_gapic_assembly_pkg(
-    name = "gapi-cloud-{{assembly_name}}-{{version}}-go",
+    name = "{{assembly_name}}-{{version}}-go",
     deps = [
         ":{{name}}_go_gapic",
         ":{{name}}_go_gapic_srcjar-test.srcjar",
         ":{{name}}_go_gapic_srcjar-metadata.srcjar",
         ":{{name}}_go_proto",
     ],
+)
+
+alias(
+    name = "gapi-cloud-{{assembly_name}}-{{version}}-go",
+    actual = ":{{assembly_name}}-{{version}}-go",
+    deprecated = "Please use :{{assembly_name}}-{{version}}-go."
 )
 
 ##############################################################################
@@ -200,12 +212,18 @@ php_gapic_library(
 
 # Open Source Packages
 php_gapic_assembly_pkg(
-    name = "google-cloud-{{assembly_name}}-{{version}}-php",
+    name = "{{assembly_name}}-{{version}}-php",
     deps = [
         ":{{name}}_php_gapic",
         ":{{name}}_php_grpc",
         ":{{name}}_php_proto",
     ],
+)
+
+alias(
+    name = "google-cloud-{{assembly_name}}-{{version}}-php",
+    actual = ":{{assembly_name}}-{{version}}-php",
+    deprecated = "Please use :{{assembly_name}}-{{version}}-php."
 )
 
 ##############################################################################
@@ -273,12 +291,18 @@ ruby_cloud_gapic_library(
 
 # Open Source Packages
 ruby_gapic_assembly_pkg(
-    name = "google-cloud-{{assembly_name}}-{{version}}-ruby",
+    name = "{{assembly_name}}-{{version}}-ruby",
     deps = [
         ":{{name}}_ruby_gapic",
         ":{{name}}_ruby_grpc",
         ":{{name}}_ruby_proto",
     ],
+)
+
+alias(
+    name = "google-cloud-{{assembly_name}}-{{version}}-ruby",
+    actual = ":{{assembly_name}}-{{version}}-ruby",
+    deprecated = "Please use :{{assembly_name}}-{{version}}-ruby."
 )
 
 ##############################################################################
@@ -316,12 +340,18 @@ csharp_gapic_library(
 
 # Open Source Packages
 csharp_gapic_assembly_pkg(
-    name = "google-cloud-{{assembly_name}}-{{version}}-csharp",
+    name = "{{assembly_name}}-{{version}}-csharp",
     deps = [
         ":{{name}}_csharp_gapic",
         ":{{name}}_csharp_grpc",
         ":{{name}}_csharp_proto",
     ],
+)
+
+alias(
+    name = "google-cloud-{{assembly_name}}-{{version}}-csharp",
+    actual = ":{{assembly_name}}-{{version}}-csharp",
+    deprecated = "Please use :{{assembly_name}}-{{version}}-csharp."
 )
 
 ##############################################################################

--- a/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.baseline
+++ b/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.baseline
@@ -88,13 +88,19 @@ java_gapic_test(
 
 # Open Source Packages
 java_gapic_assembly_gradle_pkg(
-    name = "google-cloud-example-library-v1-java",
+    name = "example-library-v1-java",
     deps = [
         ":library_java_gapic",
         ":library_java_grpc",
         ":library_java_proto",
         ":library_proto",
     ],
+)
+
+alias(
+    name = "google-cloud-example-library-v1-java",
+    actual = ":example-library-v1-go",
+    deprecated = "Please use :example-library-v1-java."
 )
 
 ##############################################################################
@@ -141,13 +147,19 @@ go_test(
 
 # Open Source Packages
 go_gapic_assembly_pkg(
-    name = "gapi-cloud-example-library-v1-go",
+    name = "example-library-v1-go",
     deps = [
         ":library_go_gapic",
         ":library_go_gapic_srcjar-test.srcjar",
         ":library_go_gapic_srcjar-metadata.srcjar",
         ":library_go_proto",
     ],
+)
+
+alias(
+    name = "gapi-cloud-example-library-v1-go",
+    actual = ":example-library-v1-go",
+    deprecated = "Please use :example-library-v1-go."
 )
 
 ##############################################################################
@@ -208,12 +220,18 @@ php_gapic_library(
 
 # Open Source Packages
 php_gapic_assembly_pkg(
-    name = "google-cloud-example-library-v1-php",
+    name = "example-library-v1-php",
     deps = [
         ":library_php_gapic",
         ":library_php_grpc",
         ":library_php_proto",
     ],
+)
+
+alias(
+    name = "google-cloud-example-library-v1-php",
+    actual = ":example-library-v1-php",
+    deprecated = "Please use :example-library-v1-php."
 )
 
 ##############################################################################
@@ -281,12 +299,18 @@ ruby_cloud_gapic_library(
 
 # Open Source Packages
 ruby_gapic_assembly_pkg(
-    name = "google-cloud-example-library-v1-ruby",
+    name = "example-library-v1-ruby",
     deps = [
         ":library_ruby_gapic",
         ":library_ruby_grpc",
         ":library_ruby_proto",
     ],
+)
+
+alias(
+    name = "google-cloud-example-library-v1-ruby",
+    actual = ":example-library-v1-ruby",
+    deprecated = "Please use :example-library-v1-ruby."
 )
 
 ##############################################################################
@@ -324,12 +348,18 @@ csharp_gapic_library(
 
 # Open Source Packages
 csharp_gapic_assembly_pkg(
-    name = "google-cloud-example-library-v1-csharp",
+    name = "example-library-v1-csharp",
     deps = [
         ":library_csharp_gapic",
         ":library_csharp_grpc",
         ":library_csharp_proto",
     ],
+)
+
+alias(
+    name = "google-cloud-example-library-v1-csharp",
+    actual = ":example-library-v1-csharp",
+    deprecated = "Please use :example-library-v1-csharp."
 )
 
 ##############################################################################

--- a/bazel/src/test/data/googleapis/google/example/library/v1legacy/BUILD.bazel.baseline
+++ b/bazel/src/test/data/googleapis/google/example/library/v1legacy/BUILD.bazel.baseline
@@ -88,13 +88,19 @@ java_gapic_test(
 
 # Open Source Packages
 java_gapic_assembly_gradle_pkg(
-    name = "google-cloud-example-library-v1-java",
+    name = "example-library-v1-java",
     deps = [
         ":library_java_gapic",
         ":library_java_grpc",
         ":library_java_proto",
         ":library_proto",
     ],
+)
+
+alias(
+    name = "google-cloud-example-library-v1-java",
+    actual = ":example-library-v1-go",
+    deprecated = "Please use :example-library-v1-java."
 )
 
 ##############################################################################
@@ -141,13 +147,19 @@ go_test(
 
 # Open Source Packages
 go_gapic_assembly_pkg(
-    name = "gapi-cloud-example-library-v1-go",
+    name = "example-library-v1-go",
     deps = [
         ":library_go_gapic",
         ":library_go_gapic_srcjar-test.srcjar",
         ":library_go_gapic_srcjar-metadata.srcjar",
         ":library_go_proto",
     ],
+)
+
+alias(
+    name = "gapi-cloud-example-library-v1-go",
+    actual = ":example-library-v1-go",
+    deprecated = "Please use :example-library-v1-go."
 )
 
 ##############################################################################
@@ -208,12 +220,18 @@ php_gapic_library(
 
 # Open Source Packages
 php_gapic_assembly_pkg(
-    name = "google-cloud-example-library-v1-php",
+    name = "example-library-v1-php",
     deps = [
         ":library_php_gapic",
         ":library_php_grpc",
         ":library_php_proto",
     ],
+)
+
+alias(
+    name = "google-cloud-example-library-v1-php",
+    actual = ":example-library-v1-php",
+    deprecated = "Please use :example-library-v1-php."
 )
 
 ##############################################################################
@@ -281,12 +299,18 @@ ruby_cloud_gapic_library(
 
 # Open Source Packages
 ruby_gapic_assembly_pkg(
-    name = "google-cloud-example-library-v1-ruby",
+    name = "example-library-v1-ruby",
     deps = [
         ":library_ruby_gapic",
         ":library_ruby_grpc",
         ":library_ruby_proto",
     ],
+)
+
+alias(
+    name = "google-cloud-example-library-v1-ruby",
+    actual = ":example-library-v1-ruby",
+    deprecated = "Please use :example-library-v1-ruby."
 )
 
 ##############################################################################
@@ -324,12 +348,18 @@ csharp_gapic_library(
 
 # Open Source Packages
 csharp_gapic_assembly_pkg(
-    name = "google-cloud-example-library-v1-csharp",
+    name = "example-library-v1-csharp",
     deps = [
         ":library_csharp_gapic",
         ":library_csharp_grpc",
         ":library_csharp_proto",
     ],
+)
+
+alias(
+    name = "google-cloud-example-library-v1-csharp",
+    actual = ":example-library-v1-csharp",
+    deprecated = "Please use :example-library-v1-csharp."
 )
 
 ##############################################################################

--- a/bazel/src/test/java/com/google/api/codegen/bazel/BuildFileGeneratorTest.java
+++ b/bazel/src/test/java/com/google/api/codegen/bazel/BuildFileGeneratorTest.java
@@ -117,11 +117,11 @@ public class BuildFileGeneratorTest {
         gapicBuildFilePath, "library_nodejs_gapic", "extra_protoc_parameters", "param2");
     buildozer.batchSetAttribute(
         gapicBuildFilePath,
-        "google-cloud-example-library-v1-csharp",
+        "example-library-v1-csharp",
         "name",
         "renamed_csharp_rule");
     buildozer.batchSetAttribute(
-        gapicBuildFilePath, "google-cloud-example-library-v1-java", "name", "renamed_java_rule");
+        gapicBuildFilePath, "example-library-v1-java", "name", "renamed_java_rule");
     buildozer.batchSetAttribute(
         gapicBuildFilePath, "library_ruby_gapic", "ruby_cloud_title", "Title with spaces");
 


### PR DESCRIPTION
This makes it easier to depend on these rules. I added a deprecated alias to maintain the current names.

closes #56 
