### PR TITLE
chore(bazel): revert Python non-service rule change

### DIFF
--- a/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.raw_api.mustache
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.raw_api.mustache
@@ -61,21 +61,28 @@ go_proto_library(
 ##############################################################################
 load(
     "@com_google_googleapis_imports//:imports.bzl",
-    "py_gapic_assembly_pkg",
-    "py_gapic_library",
+    "moved_proto_library",
+    "py_grpc_library",
+    "py_proto_library",
 )
 
-py_gapic_library(
-    name = "{{name}}_py_gapic",
+moved_proto_library(
+    name = "{{name}}_moved_proto",
     srcs = [":{{name}}_proto"],
+    deps = [
+        {{proto_deps}}
+    ],
 )
 
-# Open Source Packages
-py_gapic_assembly_pkg(
-    name = "{{assembly_name}}-{{version}}-py",
-    deps = [
-        ":{{name}}_py_gapic",
-    ],
+py_proto_library(
+    name = "{{name}}_py_proto",
+    deps = [":{{name}}_moved_proto"],
+)
+
+py_grpc_library(
+    name = "{{name}}_py_grpc",
+    srcs = [":{{name}}_moved_proto"],
+    deps = [":{{name}}_py_proto"],
 )
 
 ##############################################################################

--- a/bazel/src/test/data/googleapis/google/example/library/type/BUILD.bazel.baseline
+++ b/bazel/src/test/data/googleapis/google/example/library/type/BUILD.bazel.baseline
@@ -63,21 +63,30 @@ go_proto_library(
 ##############################################################################
 load(
     "@com_google_googleapis_imports//:imports.bzl",
-    "py_gapic_assembly_pkg",
-    "py_gapic_library",
+    "moved_proto_library",
+    "py_grpc_library",
+    "py_proto_library",
 )
 
-py_gapic_library(
-    name = "types_py_gapic",
+moved_proto_library(
+    name = "types_moved_proto",
     srcs = [":types_proto"],
+    deps = [
+        "//google/api:annotations_proto",
+        "//google/api:field_behavior_proto",
+        "//google/api:resource_proto",
+    ],
 )
 
-# Open Source Packages
-py_gapic_assembly_pkg(
-    name = "types-{{version}}-py",
-    deps = [
-        ":types_py_gapic",
-    ],
+py_proto_library(
+    name = "types_py_proto",
+    deps = [":types_moved_proto"],
+)
+
+py_grpc_library(
+    name = "types_py_grpc",
+    srcs = [":types_moved_proto"],
+    deps = [":types_py_proto"],
 )
 
 ##############################################################################


### PR DESCRIPTION
This essentially reverts #53. This is necessary because #53 makes sweeping changes to the python targets for non-product service protos, but did not account for other python targets that depended on those targets already generated. Since #53 is unreleased, it has not been used in googleapis or elsewhere yet. In order to get a bunch of other changes released, we must revert this and revisit it at a later date when we can make all the changes to the python rules at once.