### PR TITLE
fix: exclude location mixin from proto input

### DIFF
--- a/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
@@ -44,9 +44,6 @@ class BazelBuildFileView {
 
     Set<String> extraImports = new TreeSet<>();
     extraImports.add(COMMON_RESOURCES_PROTO);
-    if (bp.hasLocations() && !bp.getProtoPackage().equals("google.cloud.location")) {
-      extraImports.add("//google/cloud/location:location_proto");
-    }
     tokens.put("extra_imports", joinSetWithIndentation(extraImports));
 
     String packPrefix = bp.getProtoPackage().replace(".", "/") + '/';
@@ -127,6 +124,10 @@ class BazelBuildFileView {
 
     // Remove common_resources.proto because it is only needed for the proto_library_with_info target.
     extraImports.remove(COMMON_RESOURCES_PROTO);
+    // Add location_proto dependency for mix-in if individual language rules need it.
+    if (bp.hasLocations() && !bp.getProtoPackage().equals("google.cloud.location")) {
+      extraImports.add("//google/cloud/location:location_proto");
+    }
     actualImports.addAll(extraImports);
 
     tokens.put("java_tests", joinSetWithIndentation(javaTests));
@@ -337,6 +338,8 @@ class BazelBuildFileView {
         goImports.add(replaceLabelName(protoImport, ":monitoredres_go_proto"));
       } else if (protoImport.endsWith(":metric_proto")) {
         goImports.add(replaceLabelName(protoImport, ":metric_go_proto"));
+      } else if (protoImport.endsWith(":location_proto")) {
+        goImports.add(replaceLabelName(protoImport, ":location_go_proto"));
       }
     }
     return goImports;

--- a/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.baseline
+++ b/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.baseline
@@ -37,7 +37,6 @@ proto_library_with_info(
     name = "library_proto_with_info",
     deps = [
         ":library_proto",
-        "//google/cloud/location:location_proto",
         "//google/cloud:common_resources_proto",
     ],
 )
@@ -137,6 +136,7 @@ go_gapic_library(
     deps = [
         ":library_go_proto",
         "//google/api:httpbody_go_proto",
+        "//google/cloud/location:location_go_proto",
     ],
 )
 

--- a/bazel/src/test/data/googleapis/google/example/library/v1legacy/BUILD.bazel.baseline
+++ b/bazel/src/test/data/googleapis/google/example/library/v1legacy/BUILD.bazel.baseline
@@ -37,7 +37,6 @@ proto_library_with_info(
     name = "library_proto_with_info",
     deps = [
         ":library_proto",
-        "//google/cloud/location:location_proto",
         "//google/cloud:common_resources_proto",
     ],
 )
@@ -137,6 +136,7 @@ go_gapic_library(
     deps = [
         ":library_go_proto",
         "//google/api:httpbody_go_proto",
+        "//google/cloud/location:location_go_proto",
     ],
 )
 


### PR DESCRIPTION
In #52 the location_proto target was added to the proto_library_with_info target when it shouldn't have been. This excludes it but also includes in the go_gapic_library deps when present. 