### PR TITLE
chore: make C# grpc files end with Grpc.g.cs

### DIFF
--- a/csharp/csharp_gapic.bzl
+++ b/csharp/csharp_gapic.bzl
@@ -39,10 +39,10 @@ def csharp_grpc_library(name, srcs, deps, **kwargs):
         output_type = "grpc",
         output_suffix = ".srcjar",
         extra_args = [
-            "--include_source_info"
+            "--include_source_info",
         ],
         opt_args = [
-            "file_suffix=Grpc.g.cs"
+            "file_suffix=Grpc.g.cs",
         ],
         **kwargs
     )

--- a/csharp/csharp_gapic.bzl
+++ b/csharp/csharp_gapic.bzl
@@ -39,7 +39,10 @@ def csharp_grpc_library(name, srcs, deps, **kwargs):
         output_type = "grpc",
         output_suffix = ".srcjar",
         extra_args = [
-            "--include_source_info",
+            "--include_source_info"
+        ],
+        opt_args = [
+            "file_suffix=Grpc.g.cs"
         ],
         **kwargs
     )


### PR DESCRIPTION
 instead of just Grpc.cs (by default)