### PR TITLE
feat: make C# generated proto files end with .g.cs

### DIFF
--- a/csharp/csharp_gapic.bzl
+++ b/csharp/csharp_gapic.bzl
@@ -24,6 +24,9 @@ def csharp_proto_library(name, deps, **kwargs):
         extra_args = [
             "--include_source_info",
         ],
+        opt_args = [
+            "file_extension=.g.cs",
+        ],
         **kwargs
     )
 


### PR DESCRIPTION
This was already done for the gRPC plugin; this is for standard
type generation - messages etc.

Note: I don't know how to test this change, and definitely don't want to merge before testing. The README shows how to *use* the rules in this library, but not how to test changes...