### PR TITLE
fix(bazel): packages with service yaml but no APIs are not GAPICs

### DIFF
--- a/bazel/src/main/java/com/google/api/codegen/bazel/ApiDir.java
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/ApiDir.java
@@ -27,11 +27,13 @@ class ApiDir {
   private static String CLOUD_AUTH_SCOPE = "https://www.googleapis.com/auth/cloud-platform";
   private static String LOCATIONS_MIXIN = "name: google.cloud.location.Locations";
   private static String IAM_POLICY_MIXIN = "name: google.iam.v1.IAMPolicy";
+  private static String APIS_PROPERTY = "apis:";
 
   private final Map<String, String> serviceYamlPaths = new TreeMap<>();
   private final Map<String, Boolean> cloudScopes = new TreeMap<>();
   private final Map<String, Boolean> containLocations = new TreeMap<>();
   private final Map<String, Boolean> containIAMPolicy = new TreeMap<>();
+  private final Map<String, Boolean> containApis = new TreeMap<>();
 
   Map<String, String> getServiceYamlPaths() {
     return serviceYamlPaths;
@@ -47,6 +49,10 @@ class ApiDir {
 
   Map<String, Boolean> getContainsIAMPolicy() {
     return containIAMPolicy;
+  }
+
+  Map<String, Boolean> getContainsApis() {
+    return containApis;
   }
 
   void parseYamlFile(String fileName, String fileBody) {
@@ -65,6 +71,9 @@ class ApiDir {
       }
       if (fileBody.contains(IAM_POLICY_MIXIN)) {
         containIAMPolicy.put(verKey, true);
+      }
+      if (fileBody.contains(APIS_PROPERTY)) {
+        containApis.put(verKey, true);
       }
     }
   }

--- a/bazel/src/main/java/com/google/api/codegen/bazel/ApiVersionedDir.java
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/ApiVersionedDir.java
@@ -63,6 +63,8 @@ class ApiVersionedDir {
 
   private static String IAM_POLICY_MIXIN = "name: google.iam.v1.IAMPolicy";
 
+  private static String APIS_PROPERTY = "apis:";
+
   private static final String[] PRESERVED_PROTO_LIBRARY_STRING_ATTRIBUTES = {
     // TypeScript:
     "package_name",
@@ -171,6 +173,8 @@ class ApiVersionedDir {
 
   private boolean containsIAMPolicy;
 
+  private boolean containsApis;
+
   // Names of *_gapic_assembly_* rules (since they may be overridden by the user)
   private final Map<String, String> assemblyPkgRulesNames = new HashMap<>();
 
@@ -258,6 +262,10 @@ class ApiVersionedDir {
     return this.containsIAMPolicy;
   }
 
+  boolean hasApis() {
+    return this.containsApis;
+  }
+
   void parseYamlFile(String fileName, String fileBody) {
     // It is a gapic yaml
     Matcher m = GAPIC_YAML_TYPE.matcher(fileBody);
@@ -287,8 +295,11 @@ class ApiVersionedDir {
     if (m.find()) {
       serviceYamlPath = fileName;
 
-      // API Servic config specifies the use of the Cloud oauth scope.
+      // API Service config specifies the use of the Cloud oauth scope.
       this.cloudScope = fileBody.contains(CLOUD_AUTH_SCOPE);
+
+      // API Service config names at least one API interface exposed.
+      this.containsApis = fileBody.contains(APIS_PROPERTY);
 
       // API Serivce config has Locations API.
       if (fileBody.contains(LOCATIONS_MIXIN)) {
@@ -444,5 +455,8 @@ class ApiVersionedDir {
 
     boolean topLevelContainsIAMPolicy = parent.getContainsIAMPolicy().getOrDefault(version, false);
     containsIAMPolicy = topLevelContainsIAMPolicy ? topLevelContainsIAMPolicy : containsIAMPolicy;
+
+    boolean topLevelContainsApis = parent.getContainsApis().getOrDefault(version, false);
+    containsApis = topLevelContainsApis ? topLevelContainsApis : containsApis;
   }
 }

--- a/bazel/src/main/java/com/google/api/codegen/bazel/ApisVisitor.java
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/ApisVisitor.java
@@ -138,7 +138,7 @@ class ApisVisitor extends SimpleFileVisitor<Path> {
     String tmplType = "";
     if (bp.getProtoPackage() != null) {
       boolean isGapicLibrary =
-          bp.getServiceYamlPath() != null || bp.getServiceConfigJsonPath() != null;
+          (bp.getServiceYamlPath() != null && bp.hasApis()) || bp.getServiceConfigJsonPath() != null;
       if (isGapicLibrary) {
         bp.injectFieldsFromTopLevel();
         template = this.gapicApiTempl;

--- a/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
@@ -72,8 +72,10 @@ class BazelBuildFileView {
     tokens.put("go_proto_importpath", bp.getLangProtoPackages().get("go").split(";")[0]);
     tokens.put("go_proto_deps", joinSetWithIndentation(mapGoProtoDeps(actualImports)));
 
+    System.out.println("++++++++++ hasApis:"+bp.hasApis());
     boolean isGapicLibrary =
-        bp.getServiceYamlPath() != null || bp.getServiceConfigJsonPath() != null;
+        (bp.getServiceYamlPath() != null && bp.hasApis()) || bp.getServiceConfigJsonPath() != null;
+    System.out.println("++++++++++ isGapicLibrary:"+isGapicLibrary);
     if (!isGapicLibrary) {
       return;
     }

--- a/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
@@ -72,10 +72,8 @@ class BazelBuildFileView {
     tokens.put("go_proto_importpath", bp.getLangProtoPackages().get("go").split(";")[0]);
     tokens.put("go_proto_deps", joinSetWithIndentation(mapGoProtoDeps(actualImports)));
 
-    System.out.println("++++++++++ hasApis:"+bp.hasApis());
     boolean isGapicLibrary =
         (bp.getServiceYamlPath() != null && bp.hasApis()) || bp.getServiceConfigJsonPath() != null;
-    System.out.println("++++++++++ isGapicLibrary:"+isGapicLibrary);
     if (!isGapicLibrary) {
       return;
     }

--- a/bazel/src/test/data/googleapis/google/example/library/type/library_types.yaml
+++ b/bazel/src/test/data/googleapis/google/example/library/type/library_types.yaml
@@ -1,0 +1,7 @@
+type: google.api.Service
+config_version: 3
+name: library-types.googleapis.com
+title: Library Example types
+
+types:
+- name: google.example.library.types.Shelf


### PR DESCRIPTION
This checks if a versioned directory's service yaml has the `apis:` property which would indicate that the package is service and not just "raw" types. The latter should not have gapic targets generated for it, but is allowed to have a service yaml (although it is kind of unnecessary).