### PR TITLE
feat: generate C++ rules

### DIFF
--- a/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.gapic_api.mustache
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.gapic_api.mustache
@@ -328,4 +328,19 @@ csharp_gapic_assembly_pkg(
 ##############################################################################
 # C++
 ##############################################################################
-# Put your C++ rules here
+load(
+    "@com_google_googleapis_imports//:imports.bzl",
+    "cc_grpc_library",
+    "cc_proto_library",
+)
+
+cc_proto_library(
+    name = "{{name}}_cc_proto",
+    deps = [":{{name}}_proto"],
+)
+
+cc_grpc_library(
+    name = "{{name}}_cc_grpc",
+    srcs = [":{{name}}_proto"],
+    deps = [":{{name}}_cc_proto"],
+)

--- a/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.raw_api.mustache
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.raw_api.mustache
@@ -158,4 +158,19 @@ csharp_grpc_library(
 ##############################################################################
 # C++
 ##############################################################################
-# Put your C++ code here
+load(
+    "@com_google_googleapis_imports//:imports.bzl",
+    "cc_grpc_library",
+    "cc_proto_library",
+)
+
+cc_proto_library(
+    name = "{{name}}_cc_proto",
+    deps = [":{{name}}_proto"],
+)
+
+cc_grpc_library(
+    name = "{{name}}_cc_grpc",
+    srcs = [":{{name}}_proto"],
+    deps = [":{{name}}_cc_proto"],
+)

--- a/bazel/src/test/data/googleapis/google/example/library/type/BUILD.bazel.baseline
+++ b/bazel/src/test/data/googleapis/google/example/library/type/BUILD.bazel.baseline
@@ -162,4 +162,19 @@ csharp_grpc_library(
 ##############################################################################
 # C++
 ##############################################################################
-# Put your C++ code here
+load(
+    "@com_google_googleapis_imports//:imports.bzl",
+    "cc_grpc_library",
+    "cc_proto_library",
+)
+
+cc_proto_library(
+    name = "types_cc_proto",
+    deps = [":types_proto"],
+)
+
+cc_grpc_library(
+    name = "types_cc_grpc",
+    srcs = [":types_proto"],
+    deps = [":types_cc_proto"],
+)

--- a/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.baseline
+++ b/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.baseline
@@ -354,4 +354,19 @@ csharp_gapic_assembly_pkg(
 ##############################################################################
 # C++
 ##############################################################################
-# Put your C++ rules here
+load(
+    "@com_google_googleapis_imports//:imports.bzl",
+    "cc_grpc_library",
+    "cc_proto_library",
+)
+
+cc_proto_library(
+    name = "library_cc_proto",
+    deps = [":library_proto"],
+)
+
+cc_grpc_library(
+    name = "library_cc_grpc",
+    srcs = [":library_proto"],
+    deps = [":library_cc_proto"],
+)

--- a/bazel/src/test/data/googleapis/google/example/library/v1legacy/BUILD.bazel.baseline
+++ b/bazel/src/test/data/googleapis/google/example/library/v1legacy/BUILD.bazel.baseline
@@ -344,4 +344,19 @@ csharp_gapic_assembly_pkg(
 ##############################################################################
 # C++
 ##############################################################################
-# Put your C++ rules here
+load(
+    "@com_google_googleapis_imports//:imports.bzl",
+    "cc_grpc_library",
+    "cc_proto_library",
+)
+
+cc_proto_library(
+    name = "library_cc_proto",
+    deps = [":library_proto"],
+)
+
+cc_grpc_library(
+    name = "library_cc_grpc",
+    srcs = [":library_proto"],
+    deps = [":library_cc_proto"],
+)


### PR DESCRIPTION
This adds support to generate the C++ rules for basic proto and gRPC
libraries.

/fyi: @devjgm @scotthart 