### PR TITLE
fix(bazel): iam/location mixin java deps

### DIFF
--- a/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.gapic_api.mustache
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.gapic_api.mustache
@@ -88,7 +88,7 @@ java_gapic_assembly_gradle_pkg(
         ":{{name}}_java_gapic",
         ":{{name}}_java_grpc",
         ":{{name}}_java_proto",
-        ":{{name}}_proto",{{extra_imports_java}}
+        ":{{name}}_proto",
     ],
 )
 

--- a/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.baseline
+++ b/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.baseline
@@ -39,7 +39,9 @@ proto_library_with_info(
     name = "library_proto_with_info",
     deps = [
         ":library_proto",
+        "//google/cloud/location:location_proto",
         "//google/cloud:common_resources_proto",
+        "//google/iam/v1:iam_policy_proto",
     ],
 )
 
@@ -75,13 +77,14 @@ java_gapic_library(
     test_deps = [
         ":library_java_grpc",
         "//google/cloud/location:location_java_grpc",
+        "//google/iam/v1:iam_java_grpc",
     ],
     deps = [
         ":library_java_proto",
         "//google/api:api_java_proto",
         "//google/cloud/common:common_java_proto",
-        "//google/cloud/location:location_java_grpc",
         "//google/cloud/location:location_java_proto",
+        "//google/iam/v1:iam_java_proto",
     ],
 )
 
@@ -101,9 +104,6 @@ java_gapic_assembly_gradle_pkg(
         ":library_java_grpc",
         ":library_java_proto",
         ":library_proto",
-        "//google/cloud/location:location_java_grpc",
-        "//google/cloud/location:location_java_proto",
-        "//google/cloud/location:location_proto",
     ],
 )
 

--- a/bazel/src/test/data/googleapis/google/example/library/v1legacy/BUILD.bazel.baseline
+++ b/bazel/src/test/data/googleapis/google/example/library/v1legacy/BUILD.bazel.baseline
@@ -37,7 +37,9 @@ proto_library_with_info(
     name = "library_proto_with_info",
     deps = [
         ":library_proto",
+        "//google/cloud/location:location_proto",
         "//google/cloud:common_resources_proto",
+        "//google/iam/v1:iam_policy_proto",
     ],
 )
 
@@ -73,12 +75,13 @@ java_gapic_library(
     test_deps = [
         ":library_java_grpc",
         "//google/cloud/location:location_java_grpc",
+        "//google/iam/v1:iam_java_grpc",
     ],
     deps = [
         ":library_java_proto",
         "//google/api:api_java_proto",
-        "//google/cloud/location:location_java_grpc",
         "//google/cloud/location:location_java_proto",
+        "//google/iam/v1:iam_java_proto",
     ],
 )
 
@@ -98,9 +101,6 @@ java_gapic_assembly_gradle_pkg(
         ":library_java_grpc",
         ":library_java_proto",
         ":library_proto",
-        "//google/cloud/location:location_java_grpc",
-        "//google/cloud/location:location_java_proto",
-        "//google/cloud/location:location_proto",
     ],
 )
 


### PR DESCRIPTION
Fixes java mixin dependency generation in bazel targets. The generated deps are based on the existing PubSub & KMS targets that have mixins today.