### PR TITLE
fix(bazel): add service_yaml to py_gapic_library

### DIFF
--- a/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.gapic_api.mustache
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.gapic_api.mustache
@@ -156,6 +156,7 @@ py_gapic_library(
     name = "{{name}}_py_gapic",
     srcs = [":{{name}}_proto"],
     grpc_service_config = {{grpc_service_config}},
+    service_yaml = {{service_yaml}},
 )
 
 # Open Source Packages

--- a/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.baseline
+++ b/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.baseline
@@ -181,6 +181,7 @@ py_gapic_library(
     name = "library_py_gapic",
     srcs = [":library_proto"],
     grpc_service_config = "library_example_grpc_service_config.json",
+    service_yaml = "library_example_v1.yaml",
 )
 
 # Open Source Packages

--- a/bazel/src/test/data/googleapis/google/example/library/v1legacy/BUILD.bazel.baseline
+++ b/bazel/src/test/data/googleapis/google/example/library/v1legacy/BUILD.bazel.baseline
@@ -172,6 +172,7 @@ py_gapic_library(
     name = "library_py_gapic",
     srcs = [":library_proto"],
     grpc_service_config = "library_example_grpc_service_config.json",
+    service_yaml = "//google/example/library:library_example_v1.yaml",
 )
 
 # Open Source Packages


### PR DESCRIPTION
gapic-generator-python supports consumption of the `service_yaml` so we should ensure it is always added to the `py_gapic_library` target.

cc: @atulep @vam-google 