### PR TITLE
feat: Add rest_numeric_enums to Ruby build rule template

### DIFF
--- a/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.gapic_api.mustache
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.gapic_api.mustache
@@ -288,6 +288,7 @@ ruby_cloud_gapic_library(
     ],
     grpc_service_config = {{grpc_service_config}},
     service_yaml = {{service_yaml}},
+    rest_numeric_enums = {{rest_numeric_enums}},
     deps = [
         ":{{name}}_ruby_grpc",
         ":{{name}}_ruby_proto",

--- a/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.baseline
+++ b/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.baseline
@@ -315,6 +315,7 @@ ruby_cloud_gapic_library(
     ],
     grpc_service_config = "library_example_grpc_service_config.json",
     service_yaml = "library_example_v1.yaml",
+    rest_numeric_enums = True,
     deps = [
         ":library_ruby_grpc",
         ":library_ruby_proto",

--- a/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.updated.baseline
+++ b/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.updated.baseline
@@ -319,7 +319,7 @@ ruby_cloud_gapic_library(
     srcs = [":library_proto_with_info"],
     extra_protoc_parameters = ["ruby-cloud-gem-name=google-cloud-example-library-v1"],
     grpc_service_config = "library_example_grpc_service_config.json",
-    rest_numeric_enums = False,
+    rest_numeric_enums = True,
     ruby_cloud_title = "Title with spaces",
     service_yaml = "library_example_v1.yaml",
     deps = [

--- a/bazel/src/test/data/googleapis/google/example/library/v1legacy/BUILD.bazel.baseline
+++ b/bazel/src/test/data/googleapis/google/example/library/v1legacy/BUILD.bazel.baseline
@@ -305,6 +305,7 @@ ruby_cloud_gapic_library(
     ],
     grpc_service_config = "library_example_grpc_service_config.json",
     service_yaml = "//google/example/library:library_example_v1.yaml",
+    rest_numeric_enums = True,
     deps = [
         ":library_ruby_grpc",
         ":library_ruby_proto",


### PR DESCRIPTION
The current Ruby build rules take and ignore `**kwargs`, so this should be safe even before the build rules have been updated to recognize this parameter explicitly.