### PR TITLE
feat: Set rest_numeric_enums parameter explicitly for all gapic rules

### DIFF
--- a/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.gapic_api.mustache
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.gapic_api.mustache
@@ -64,6 +64,7 @@ java_gapic_library(
     srcs = [":{{name}}_proto_with_info"],
     gapic_yaml = {{gapic_yaml}},
     grpc_service_config = {{grpc_service_config}},
+    rest_numeric_enums = {{rest_numeric_enums}},
     service_yaml = {{service_yaml}},
     test_deps = [
         ":{{name}}_java_grpc",{{java_gapic_test_deps}}
@@ -122,9 +123,9 @@ go_gapic_library(
     grpc_service_config = {{grpc_service_config}},
     importpath = "{{go_gapic_importpath}}",
     metadata = True,
+    rest_numeric_enums = {{rest_numeric_enums}},
     service_yaml = {{service_yaml}},
     transport = {{transport}},
-    rest_numeric_enums = {{rest_numeric_enums}},
     deps = [
         ":{{name}}_go_proto",{{go_gapic_deps}}
     ],
@@ -162,6 +163,7 @@ py_gapic_library(
     name = "{{name}}_py_gapic",
     srcs = [":{{name}}_proto"],
     grpc_service_config = {{grpc_service_config}},
+    rest_numeric_enums = {{rest_numeric_enums}},
     service_yaml = {{service_yaml}},
     transport = {{transport}},
     deps = [
@@ -213,6 +215,7 @@ php_gapic_library(
     name = "{{name}}_php_gapic",
     srcs = [":{{name}}_proto_with_info"],
     grpc_service_config = {{grpc_service_config}},
+    rest_numeric_enums = {{rest_numeric_enums}},
     service_yaml = {{service_yaml}},
     deps = [
         ":{{name}}_php_grpc",
@@ -246,6 +249,7 @@ nodejs_gapic_library(
     extra_protoc_parameters = ["metadata"],
     grpc_service_config = {{grpc_service_config}},
     package = "{{package}}",
+    rest_numeric_enums = {{rest_numeric_enums}},
     service_yaml = {{service_yaml}},
     deps = [],
 )
@@ -287,8 +291,8 @@ ruby_cloud_gapic_library(
         "ruby-cloud-gem-name=google-cloud-{{assembly_name}}-{{version}}",
     ],
     grpc_service_config = {{grpc_service_config}},
-    service_yaml = {{service_yaml}},
     rest_numeric_enums = {{rest_numeric_enums}},
+    service_yaml = {{service_yaml}},
     deps = [
         ":{{name}}_ruby_grpc",
         ":{{name}}_ruby_proto",
@@ -332,6 +336,7 @@ csharp_gapic_library(
     srcs = [":{{name}}_proto_with_info"],
     common_resources_config = "@gax_dotnet//:Google.Api.Gax/ResourceNames/CommonResourcesConfig.json",
     grpc_service_config = {{grpc_service_config}},
+    rest_numeric_enums = {{rest_numeric_enums}},
     service_yaml = {{service_yaml}},
     deps = [
         ":{{name}}_csharp_grpc",

--- a/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.baseline
+++ b/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.baseline
@@ -73,6 +73,7 @@ java_gapic_library(
     srcs = [":library_proto_with_info"],
     gapic_yaml = None,
     grpc_service_config = "library_example_grpc_service_config.json",
+    rest_numeric_enums = True,
     service_yaml = "library_example_v1.yaml",
     test_deps = [
         ":library_java_grpc",
@@ -141,9 +142,9 @@ go_gapic_library(
     grpc_service_config = "library_example_grpc_service_config.json",
     importpath = "cloud.google.com/go/example/library/apiv1;library",
     metadata = True,
+    rest_numeric_enums = True,
     service_yaml = "library_example_v1.yaml",
     transport = "grpc+rest",
-    rest_numeric_enums = True,
     deps = [
         ":library_go_proto",
         "//google/api:httpbody_go_proto",
@@ -188,6 +189,7 @@ py_gapic_library(
     name = "library_py_gapic",
     srcs = [":library_proto"],
     grpc_service_config = "library_example_grpc_service_config.json",
+    rest_numeric_enums = True,
     service_yaml = "library_example_v1.yaml",
     transport = "grpc+rest",
     deps = [
@@ -239,6 +241,7 @@ php_gapic_library(
     name = "library_php_gapic",
     srcs = [":library_proto_with_info"],
     grpc_service_config = "library_example_grpc_service_config.json",
+    rest_numeric_enums = True,
     service_yaml = "library_example_v1.yaml",
     deps = [
         ":library_php_grpc",
@@ -272,6 +275,7 @@ nodejs_gapic_library(
     extra_protoc_parameters = ["metadata"],
     grpc_service_config = "library_example_grpc_service_config.json",
     package = "google.example.library.v1",
+    rest_numeric_enums = True,
     service_yaml = "library_example_v1.yaml",
     deps = [],
 )
@@ -314,8 +318,8 @@ ruby_cloud_gapic_library(
         "ruby-cloud-gem-name=google-cloud-example-library-v1",
     ],
     grpc_service_config = "library_example_grpc_service_config.json",
-    service_yaml = "library_example_v1.yaml",
     rest_numeric_enums = True,
+    service_yaml = "library_example_v1.yaml",
     deps = [
         ":library_ruby_grpc",
         ":library_ruby_proto",
@@ -359,6 +363,7 @@ csharp_gapic_library(
     srcs = [":library_proto_with_info"],
     common_resources_config = "@gax_dotnet//:Google.Api.Gax/ResourceNames/CommonResourcesConfig.json",
     grpc_service_config = "library_example_grpc_service_config.json",
+    rest_numeric_enums = True,
     service_yaml = "library_example_v1.yaml",
     deps = [
         ":library_csharp_grpc",

--- a/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.updated.baseline
+++ b/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.updated.baseline
@@ -73,7 +73,7 @@ java_gapic_library(
     srcs = [":library_proto_with_info"],
     gapic_yaml = None,
     grpc_service_config = "library_example_grpc_service_config.json",
-    rest_numeric_enums = False,
+    rest_numeric_enums = True,
     service_yaml = "library_example_v1.yaml",
     test_deps = [
         ":library_java_grpc",
@@ -189,7 +189,7 @@ py_gapic_library(
     name = "library_py_gapic",
     srcs = [":library_proto"],
     grpc_service_config = "library_example_grpc_service_config.json",
-    rest_numeric_enums = False,
+    rest_numeric_enums = True,
     service_yaml = "library_example_v1.yaml",
     transport = "grpc+rest",
     deps = [
@@ -241,7 +241,7 @@ php_gapic_library(
     name = "library_php_gapic",
     srcs = [":library_proto_with_info"],
     grpc_service_config = "library_example_grpc_service_config.json",
-    rest_numeric_enums = False,
+    rest_numeric_enums = True,
     service_yaml = "library_example_v1.yaml",
     deps = [
         ":library_php_grpc",
@@ -278,7 +278,7 @@ nodejs_gapic_library(
     ],
     grpc_service_config = "library_example_grpc_service_config.json",
     package = "google.example.library.v1",
-    rest_numeric_enums = False,
+    rest_numeric_enums = True,
     service_yaml = "library_example_v1.yaml",
     deps = [],
 )
@@ -365,7 +365,7 @@ csharp_gapic_library(
     srcs = [":library_proto_with_info"],
     common_resources_config = "@gax_dotnet//:Google.Api.Gax/ResourceNames/CommonResourcesConfig.json",
     grpc_service_config = "library_example_grpc_service_config.json",
-    rest_numeric_enums = False,
+    rest_numeric_enums = True,
     service_yaml = "library_example_v1.yaml",
     deps = [
         ":library_csharp_grpc",

--- a/bazel/src/test/data/googleapis/google/example/library/v1legacy/BUILD.bazel.baseline
+++ b/bazel/src/test/data/googleapis/google/example/library/v1legacy/BUILD.bazel.baseline
@@ -71,6 +71,7 @@ java_gapic_library(
     srcs = [":library_proto_with_info"],
     gapic_yaml = "library_example_gapic.yaml",
     grpc_service_config = "library_example_grpc_service_config.json",
+    rest_numeric_enums = True,
     service_yaml = "//google/example/library:library_example_v1.yaml",
     test_deps = [
         ":library_java_grpc",
@@ -136,9 +137,9 @@ go_gapic_library(
     grpc_service_config = "library_example_grpc_service_config.json",
     importpath = "cloud.google.com/go/example/library/apiv1;library",
     metadata = True,
+    rest_numeric_enums = True,
     service_yaml = "//google/example/library:library_example_v1.yaml",
     transport = "grpc+rest",
-    rest_numeric_enums = True,
     deps = [
         ":library_go_proto",
         "//google/api:httpbody_go_proto",
@@ -179,6 +180,7 @@ py_gapic_library(
     name = "library_py_gapic",
     srcs = [":library_proto"],
     grpc_service_config = "library_example_grpc_service_config.json",
+    rest_numeric_enums = True,
     service_yaml = "//google/example/library:library_example_v1.yaml",
     transport = "grpc+rest",
     deps = [
@@ -230,6 +232,7 @@ php_gapic_library(
     name = "library_php_gapic",
     srcs = [":library_proto_with_info"],
     grpc_service_config = "library_example_grpc_service_config.json",
+    rest_numeric_enums = True,
     service_yaml = "//google/example/library:library_example_v1.yaml",
     deps = [
         ":library_php_grpc",
@@ -263,6 +266,7 @@ nodejs_gapic_library(
     extra_protoc_parameters = ["metadata"],
     grpc_service_config = "library_example_grpc_service_config.json",
     package = "google.example.library.v1",
+    rest_numeric_enums = True,
     service_yaml = "//google/example/library:library_example_v1.yaml",
     deps = [],
 )
@@ -304,8 +308,8 @@ ruby_cloud_gapic_library(
         "ruby-cloud-gem-name=google-cloud-example-library-v1",
     ],
     grpc_service_config = "library_example_grpc_service_config.json",
-    service_yaml = "//google/example/library:library_example_v1.yaml",
     rest_numeric_enums = True,
+    service_yaml = "//google/example/library:library_example_v1.yaml",
     deps = [
         ":library_ruby_grpc",
         ":library_ruby_proto",
@@ -349,6 +353,7 @@ csharp_gapic_library(
     srcs = [":library_proto_with_info"],
     common_resources_config = "@gax_dotnet//:Google.Api.Gax/ResourceNames/CommonResourcesConfig.json",
     grpc_service_config = "library_example_grpc_service_config.json",
+    rest_numeric_enums = True,
     service_yaml = "//google/example/library:library_example_v1.yaml",
     deps = [
         ":library_csharp_grpc",


### PR DESCRIPTION
There is another CL in googleapis, setting `rest_numeric_enums = False` for all rules explicitly. Since the rest_numeric_enums is in the list of reserverd parameters (not modified by the builf file generator during regeneration) setting `rest_numeric_enums = True` by default becomes safe, because all current rules in googleapis will be set to False and regeneration will not affect that (i.e. will not accidentally set it to True). This change is in the context of REGAPIC rollout.