### PR TITLE
feat: enable `transport = "grpc+rest"` by default for nodejs and php rules

### DIFF
--- a/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.gapic_api.mustache
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.gapic_api.mustache
@@ -217,6 +217,7 @@ php_gapic_library(
     grpc_service_config = {{grpc_service_config}},
     rest_numeric_enums = {{rest_numeric_enums}},
     service_yaml = {{service_yaml}},
+    transport = {{transport}},
     deps = [
         ":{{name}}_php_grpc",
         ":{{name}}_php_proto",
@@ -251,6 +252,7 @@ nodejs_gapic_library(
     package = "{{package}}",
     rest_numeric_enums = {{rest_numeric_enums}},
     service_yaml = {{service_yaml}},
+    transport = {{transport}},
     deps = [],
 )
 

--- a/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.baseline
+++ b/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.baseline
@@ -243,6 +243,7 @@ php_gapic_library(
     grpc_service_config = "library_example_grpc_service_config.json",
     rest_numeric_enums = True,
     service_yaml = "library_example_v1.yaml",
+    transport = "grpc+rest",
     deps = [
         ":library_php_grpc",
         ":library_php_proto",
@@ -277,6 +278,7 @@ nodejs_gapic_library(
     package = "google.example.library.v1",
     rest_numeric_enums = True,
     service_yaml = "library_example_v1.yaml",
+    transport = "grpc+rest",
     deps = [],
 )
 

--- a/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.updated.baseline
+++ b/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.updated.baseline
@@ -243,6 +243,7 @@ php_gapic_library(
     grpc_service_config = "library_example_grpc_service_config.json",
     rest_numeric_enums = True,
     service_yaml = "library_example_v1.yaml",
+    transport = "grpc+rest",
     deps = [
         ":library_php_grpc",
         ":library_php_proto",
@@ -280,6 +281,7 @@ nodejs_gapic_library(
     package = "google.example.library.v1",
     rest_numeric_enums = True,
     service_yaml = "library_example_v1.yaml",
+    transport = "grpc+rest",
     deps = [],
 )
 

--- a/bazel/src/test/data/googleapis/google/example/library/v1legacy/BUILD.bazel.baseline
+++ b/bazel/src/test/data/googleapis/google/example/library/v1legacy/BUILD.bazel.baseline
@@ -234,6 +234,7 @@ php_gapic_library(
     grpc_service_config = "library_example_grpc_service_config.json",
     rest_numeric_enums = True,
     service_yaml = "//google/example/library:library_example_v1.yaml",
+    transport = "grpc+rest",
     deps = [
         ":library_php_grpc",
         ":library_php_proto",
@@ -268,6 +269,7 @@ nodejs_gapic_library(
     package = "google.example.library.v1",
     rest_numeric_enums = True,
     service_yaml = "//google/example/library:library_example_v1.yaml",
+    transport = "grpc+rest",
     deps = [],
 )
 


### PR DESCRIPTION
For both of these langauges `transport = "grpc+rest"` is a default behavior. Enabling it here for consistency and for easier regapic rollout and clearer description of what is actually being generated in every build file (i.e. by looking into the file it is easy to see which transport is being generated without going into default transports considerations).