### PR TITLE
fix(bazel): handle single transport java test gen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,6 @@ bazel-*
 *.sw*
 *.vim
 
+# VSCode
+.vscode
 

--- a/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
@@ -145,10 +145,15 @@ class BazelBuildFileView {
                   .getOrDefault(bp.getProtoPackage() + "." + service, service)
               // Default service name as it appears in the proto.
               : service;
-      if (javaTransport.contains("grpc")) {
+      
+      // Single transport OR grpc+rest results in test file names omitting the
+      // transport that the test applies to.
+      if (javaTransport.contains("grpc") || javaTransport.equals("rest")) {
         javaTests.add(javaPackage + "." + actualService + "ClientTest");
       }
-      if (javaTransport.contains("rest")) {
+      // Double transport (i.e. both grpc and rest) results in rest tests being
+      // named as the transport variant.
+      if (javaTransport.contains("rest") && javaTransport.contains("grpc")) {
         javaTests.add(javaPackage + "." + actualService + "ClientHttpJsonTest");
       }
     }

--- a/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.updated.baseline
+++ b/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.updated.baseline
@@ -84,7 +84,7 @@ java_gapic_library(
 java_gapic_test(
     name = "library_java_gapic_test_suite",
     test_classes = [
-        "com.google.example.library.v1.LibraryServiceClientHttpJsonTest",
+        "com.google.example.library.v1.LibraryServiceClientTest",
     ],
     runtime_deps = [":library_java_gapic_test"],
 )


### PR DESCRIPTION
When there is only one transport, the generated test file names don't include the transport i.e. with just `rest` configured the generated test name is `com.google.cloud.foo.v1.FooServiceClientTest` instead of the `HttpJsonTest` variant.

Also add `.vscode` to the .gitignore.