### PR TITLE
feat(bazel): change GAPIC check to service count

### DIFF
--- a/bazel/src/main/java/com/google/api/codegen/bazel/ApisVisitor.java
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/ApisVisitor.java
@@ -149,8 +149,7 @@ class ApisVisitor extends SimpleFileVisitor<Path> {
     boolean preserveExisting = false;
     String tmplType = "";
     if (bp.getProtoPackage() != null) {
-      boolean isGapicLibrary =
-          bp.getServiceYamlPath() != null || bp.getServiceConfigJsonPath() != null;
+      boolean isGapicLibrary = !bp.getServices().isEmpty();;
       if (isGapicLibrary) {
         bp.injectFieldsFromTopLevel();
         template = this.gapicApiTempl;

--- a/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
@@ -92,8 +92,9 @@ class BazelBuildFileView {
     tokens.put("go_proto_importpath", bp.getLangProtoPackages().get("go").split(";")[0]);
     tokens.put("go_proto_deps", joinSetWithIndentation(mapGoProtoDeps(actualImports)));
 
-    boolean isGapicLibrary =
-        bp.getServiceYamlPath() != null || bp.getServiceConfigJsonPath() != null;
+    // If there are no proto services, then there is no reason to generate GAPIC library targets. This is a
+    // simple proto type directory with no API definitions.
+    boolean isGapicLibrary = !bp.getServices().isEmpty();
     if (!isGapicLibrary) {
       tokens.put("type_only_assmebly_name", typeOnlyAssemblyName(bp.getProtoPackage()));
       return;


### PR DESCRIPTION
It is probably a more accurate heuristic for GAPIC library generation to use the presence of proto `service` definitions.

We have many more plain type packages these days, some with a service config published alongside it (unnecessarily).