### PR TITLE
fix(bazel): php_gapic_assembly_pkg for type-only pkg

### DIFF
--- a/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.raw_api.mustache
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.raw_api.mustache
@@ -58,7 +58,7 @@ go_proto_library(
 )
 
 go_gapic_assembly_pkg(
-    name = "{{type_only_assmebly_name}}-go",
+    name = "{{type_only_assembly_name}}-go",
     deps = [
         ":{{name}}_go_proto",
     ],
@@ -115,7 +115,7 @@ php_grpc_library(
 )
 
 php_gapic_assembly_pkg(
-    name = "{{type_only_assmebly_name}}-php",
+    name = "{{type_only_assembly_name}}-php",
     deps = [
         ":{{name}}_php_proto",
     ],

--- a/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.raw_api.mustache
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.raw_api.mustache
@@ -98,6 +98,7 @@ py_grpc_library(
 ##############################################################################
 load(
     "@com_google_googleapis_imports//:imports.bzl",
+    "php_gapic_assembly_pkg",
     "php_grpc_library",
     "php_proto_library",
 )
@@ -111,6 +112,13 @@ php_grpc_library(
     name = "{{name}}_php_grpc",
     srcs = [":{{name}}_proto"],
     deps = [":{{name}}_php_proto"],
+)
+
+php_gapic_assembly_pkg(
+    name = "{{type_only_assmebly_name}}-php",
+    deps = [
+        ":{{name}}_php_proto",
+    ],
 )
 
 ##############################################################################

--- a/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
@@ -96,7 +96,7 @@ class BazelBuildFileView {
     // simple proto type directory with no API definitions.
     boolean isGapicLibrary = !bp.getServices().isEmpty();
     if (!isGapicLibrary) {
-      tokens.put("type_only_assmebly_name", typeOnlyAssemblyName(bp.getProtoPackage()));
+      tokens.put("type_only_assembly_name", typeOnlyAssemblyName(bp.getProtoPackage()));
       return;
     }
 

--- a/bazel/src/test/data/googleapis/google/example/library/type/BUILD.bazel.baseline
+++ b/bazel/src/test/data/googleapis/google/example/library/type/BUILD.bazel.baseline
@@ -102,6 +102,7 @@ py_grpc_library(
 ##############################################################################
 load(
     "@com_google_googleapis_imports//:imports.bzl",
+    "php_gapic_assembly_pkg",
     "php_grpc_library",
     "php_proto_library",
 )
@@ -115,6 +116,13 @@ php_grpc_library(
     name = "types_php_grpc",
     srcs = [":types_proto"],
     deps = [":types_php_proto"],
+)
+
+php_gapic_assembly_pkg(
+    name = "library-types-php",
+    deps = [
+        ":types_php_proto",
+    ],
 )
 
 ##############################################################################


### PR DESCRIPTION
Similar to #139, we want to generate the `php_gapic_assembly_pkg` target for the type-only packages so that they can be generated using our client library infrastructure.

Note: explicitly exclude the `php_grpc_library` target from the `deps` because these are type-only protos and because the `php_grpc_library` targets will eventually be removed (they are actually unnecessary in our stack).

cc: @bshaffer