### PR TITLE
fix(bazel): add lro dep for mixin only

### DIFF
--- a/bazel/src/main/java/com/google/api/codegen/bazel/ApiVersionedDir.java
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/ApiVersionedDir.java
@@ -63,6 +63,8 @@ class ApiVersionedDir {
 
   private static String IAM_POLICY_MIXIN = "name: google.iam.v1.IAMPolicy";
 
+  private static String LRO_MIXIN = "name: google.longrunning.Operations";
+
   private static final String[] PRESERVED_PROTO_LIBRARY_STRING_ATTRIBUTES = {
     // Multiple languages:
     "package_name",
@@ -189,6 +191,8 @@ class ApiVersionedDir {
 
   private boolean containsIAMPolicy;
 
+  private boolean containsLRO;
+
   // If the user provided the transport flag on the command line, it should be respected,
   // regardless of a preexisting value.
   private boolean forceTransport;
@@ -301,6 +305,10 @@ class ApiVersionedDir {
     return this.containsIAMPolicy;
   }
 
+  boolean hasLRO() {
+    return this.containsLRO;
+  }
+
   void parseYamlFile(String fileName, String fileBody) {
     // It is a gapic yaml
     Matcher m = GAPIC_YAML_TYPE.matcher(fileBody);
@@ -341,6 +349,11 @@ class ApiVersionedDir {
       // API Serivce config has IAMPolicy API.
       if (fileBody.contains(IAM_POLICY_MIXIN)) {
         this.containsIAMPolicy = true;
+      }
+
+      // API Serivce config has LRO API.
+      if (fileBody.contains(LRO_MIXIN)) {
+        this.containsLRO = true;
       }
     }
   }

--- a/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
@@ -51,23 +51,8 @@ class BazelBuildFileView {
       javaTransport = transport;
     }
 
-    Set<String> extraProtosNodeJS = new TreeSet<>();
-    Set<String> extraImports = new TreeSet<>();
-    extraImports.add(COMMON_RESOURCES_PROTO);
-    // Add location_proto dependency for mix-in if individual language rules need it.
-    if (bp.hasLocations() && !bp.getProtoPackage().equals("google.cloud.location")) {
-      extraImports.add("//google/cloud/location:location_proto");
-    }
-    // Add iam_policy_proto dependency for mix-in if individual language rules need it.
-    if (bp.hasIAMPolicy() && !bp.getProtoPackage().equals("google.iam.v1")) {
-      extraImports.add("//google/iam/v1:iam_policy_proto");
-    }
-    tokens.put("extra_imports", joinSetWithIndentation(extraImports));
-    // Remove common_resources.proto because it is only needed for the proto_library_with_info
-    // target.
-    extraImports.remove(COMMON_RESOURCES_PROTO);
-
     String packPrefix = bp.getProtoPackage().replace(".", "/") + '/';
+    Set<String> extraProtosNodeJS = new TreeSet<>();
     Set<String> actualImports = new TreeSet<>();
     for (String imp : bp.getImports()) {
       if (imp.startsWith(packPrefix) && imp.indexOf('/', packPrefix.length()) == -1) {
@@ -87,10 +72,34 @@ class BazelBuildFileView {
       }
       actualImports.add(actualImport);
     }
+
+    Set<String> extraImports = new TreeSet<>();
+    extraImports.add(COMMON_RESOURCES_PROTO);
+    // Add location_proto dependency for mix-in if individual language rules need it.
+    if (bp.hasLocations() && !bp.getProtoPackage().equals("google.cloud.location")) {
+      extraImports.add("//google/cloud/location:location_proto");
+    }
+    // Add iam_policy_proto dependency for mix-in if individual language rules need it.
+    if (bp.hasIAMPolicy() && !bp.getProtoPackage().equals("google.iam.v1")) {
+      extraImports.add("//google/iam/v1:iam_policy_proto");
+    }
+    // Add operations_proto dependency for mix-in if individual language rules need it.
+    // Typically, the dependency is already there because the protos depend on it. In
+    // some cases though, the mixin may declared when the protos do not depend on it.
+    if (bp.hasLRO() && !bp.getProtoPackage().equals("google.longrunning")) {
+      // Using actualImports is important, we want to spoof the dependency as if the
+      // proto depended on it, like most do.
+      actualImports.add("//google/longrunning:operations_proto");
+    }
+    tokens.put("extra_imports", joinSetWithIndentation(extraImports));
     tokens.put("proto_deps", joinSetWithIndentation(actualImports));
     tokens.put("extra_protos_nodejs", joinSetWithIndentationNl(extraProtosNodeJS));
     tokens.put("go_proto_importpath", bp.getLangProtoPackages().get("go").split(";")[0]);
     tokens.put("go_proto_deps", joinSetWithIndentation(mapGoProtoDeps(actualImports)));
+
+    // Remove common_resources.proto because it is only needed for the proto_library_with_info
+    // target.
+    extraImports.remove(COMMON_RESOURCES_PROTO);
 
     // If there are no proto services, then there is no reason to generate GAPIC library targets. This is a
     // simple proto type directory with no API definitions.


### PR DESCRIPTION
Adds an import dependency for LRO if the mixin is specified. This is usually a no-op, because when the LRO mixin is present, the service almost always imports of the `google/longrunning/operations.proto` already. However, there are some cases where the mixin is specified, when a specific proto package within a multipackage service (e.g. firestore, spanner, bigquery) doesn't necessarily import it. So, we must spoof the dependency for `build_gen` so that the the proper dependencies are generated for the LRO mixin. This is kind of like what happens for the other two mixins.

Note: I rearranged some of the existing code, namely the construction of the `extraImports` for the mixins after the `actualImports` had been resolved.

Fixes http://b/272063457. Tested it on this use case.