### PR TITLE
feat(bazel): generate/retain php migration_mode

### DIFF
--- a/bazel/src/main/java/com/google/api/codegen/bazel/ApiVersionedDir.java
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/ApiVersionedDir.java
@@ -80,7 +80,9 @@ class ApiVersionedDir {
     // C#:
     "generate_nongapic_package",
     // Go:
-    "release_level"
+    "release_level",
+    // PHP:
+    "migration_mode",
     // Other languages: add below
   };
 
@@ -219,6 +221,15 @@ class ApiVersionedDir {
   String getJavaTransportOverride() {
     Map<String, String> javaGapicOverrides = this.overriddenStringAttributes.get(name + "_java_gapic");
     return javaGapicOverrides != null ? javaGapicOverrides.get("transport") : null;
+  }
+
+  // Returns the value saved from the existing BUILD.bazel file's php_gapic_library target
+  // `migration_mode` attribute. This will default to PRE_MIGRATION_SURFACE_ONLY to start.
+  // The allowed values are defined in
+  // https://github.com/googleapis/gapic-generator-php/blob/main/src/Utils/MigrationMode.php.
+  String getPhpMigrationMode() {
+    Map<String, String> phpGapicOverrides = this.overriddenStringAttributes.get(name + "_php_gapic");
+    return phpGapicOverrides != null ? phpGapicOverrides.get("migration_mode") : "PRE_MIGRATION_SURFACE_ONLY";
   }
 
   void setParent(ApiDir parent) {

--- a/bazel/src/main/java/com/google/api/codegen/bazel/ApiVersionedDir.java
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/ApiVersionedDir.java
@@ -229,7 +229,11 @@ class ApiVersionedDir {
   // https://github.com/googleapis/gapic-generator-php/blob/main/src/Utils/MigrationMode.php.
   String getPhpMigrationMode() {
     Map<String, String> phpGapicOverrides = this.overriddenStringAttributes.get(name + "_php_gapic");
-    return phpGapicOverrides != null ? phpGapicOverrides.get("migration_mode") : "PRE_MIGRATION_SURFACE_ONLY";
+    String migrationMode = "PRE_MIGRATION_SURFACE_ONLY";
+    if (phpGapicOverrides != null && phpGapicOverrides.get("migration_mode") != null) {
+      migrationMode = phpGapicOverrides.get("migration_mode");
+    }
+    return migrationMode;
   }
 
   void setParent(ApiDir parent) {

--- a/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.gapic_api.mustache
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.gapic_api.mustache
@@ -206,7 +206,7 @@ php_gapic_library(
     srcs = [":{{name}}_proto_with_info"],
     grpc_service_config = {{grpc_service_config}},
     rest_numeric_enums = {{rest_numeric_enums}},
-    migration_mode = "{{migration_mode}}",
+    migration_mode = {{migration_mode}},
     service_yaml = {{service_yaml}},
     transport = {{transport}},
     deps = [

--- a/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.gapic_api.mustache
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.gapic_api.mustache
@@ -206,6 +206,7 @@ php_gapic_library(
     srcs = [":{{name}}_proto_with_info"],
     grpc_service_config = {{grpc_service_config}},
     rest_numeric_enums = {{rest_numeric_enums}},
+    migration_mode = "{{migration_mode}}",
     service_yaml = {{service_yaml}},
     transport = {{transport}},
     deps = [

--- a/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
@@ -43,6 +43,8 @@ class BazelBuildFileView {
     tokens.put("proto_srcs", joinSetWithIndentation(bp.getProtos()));
     tokens.put("version", bp.getVersion());
     tokens.put("package", bp.getProtoPackage());
+    tokens.put("migration_mode", bp.getPhpMigrationMode());
+
 
     // For regeneration of Java rules, we are particularly interested in what the saved transport value was,
     // if there was one, in order to correctly generate, or not, the rest/grpc specific targets and labels.
@@ -50,7 +52,6 @@ class BazelBuildFileView {
     if (javaTransport == null) {
       javaTransport = transport;
     }
-
     String packPrefix = bp.getProtoPackage().replace(".", "/") + '/';
     Set<String> extraProtosNodeJS = new TreeSet<>();
     Set<String> actualImports = new TreeSet<>();

--- a/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
@@ -43,7 +43,7 @@ class BazelBuildFileView {
     tokens.put("proto_srcs", joinSetWithIndentation(bp.getProtos()));
     tokens.put("version", bp.getVersion());
     tokens.put("package", bp.getProtoPackage());
-    tokens.put("migration_mode", bp.getPhpMigrationMode());
+    tokens.put("migration_mode", '"' + bp.getPhpMigrationMode() + '"');
 
 
     // For regeneration of Java rules, we are particularly interested in what the saved transport value was,

--- a/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.baseline
+++ b/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.baseline
@@ -245,6 +245,7 @@ php_gapic_library(
     srcs = [":library_proto_with_info"],
     grpc_service_config = "library_example_grpc_service_config.json",
     rest_numeric_enums = True,
+    migration_mode = "PRE_MIGRATION_SURFACE_ONLY",
     service_yaml = "library_example_v1.yaml",
     transport = "grpc+rest",
     deps = [

--- a/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.updated.baseline
+++ b/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.updated.baseline
@@ -232,6 +232,7 @@ php_gapic_library(
     name = "library_php_gapic",
     srcs = [":library_proto_with_info"],
     grpc_service_config = "library_example_grpc_service_config.json",
+    migration_mode = "NEW_SURFACE_ONLY",
     rest_numeric_enums = True,
     service_yaml = "library_example_v1.yaml",
     transport = "grpc+rest",

--- a/bazel/src/test/data/googleapis/google/example/library/v1legacy/BUILD.bazel.baseline
+++ b/bazel/src/test/data/googleapis/google/example/library/v1legacy/BUILD.bazel.baseline
@@ -235,6 +235,7 @@ php_gapic_library(
     srcs = [":library_proto_with_info"],
     grpc_service_config = "library_example_grpc_service_config.json",
     rest_numeric_enums = True,
+    migration_mode = "PRE_MIGRATION_SURFACE_ONLY",
     service_yaml = "//google/example/library:library_example_v1.yaml",
     transport = "grpc+rest",
     deps = [

--- a/bazel/src/test/java/com/google/api/codegen/bazel/BuildFileGeneratorTest.java
+++ b/bazel/src/test/java/com/google/api/codegen/bazel/BuildFileGeneratorTest.java
@@ -137,6 +137,8 @@ public class BuildFileGeneratorTest {
         gapicBuildFilePath, "library_py_gapic", "rest_numeric_enums");
     buildozer.batchSetStringAttribute(
         gapicBuildFilePath, "library_go_gapic", "rest_numeric_enums", "Apennines");
+    buildozer.batchSetStringAttribute(
+        gapicBuildFilePath, "library_php_gapic", "migration_mode", "NEW_SURFACE_ONLY");
 
     // The following values should NOT be preserved:
     buildozer.batchSetStringAttribute(


### PR DESCRIPTION
The `php_gapic_library` `migration_mode` attribute controls which surface version is generated. The default value will start as `PRE_MIGRATION_SURFACE_ONLY`.

cc @bshaffer 