### PR TITLE
feat(bazel): new php libs use new_surface_only

### DIFF
--- a/bazel/src/main/java/com/google/api/codegen/bazel/ApiVersionedDir.java
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/ApiVersionedDir.java
@@ -224,13 +224,22 @@ class ApiVersionedDir {
   }
 
   // Returns the value saved from the existing BUILD.bazel file's php_gapic_library target
-  // `migration_mode` attribute. This will default to PRE_MIGRATION_SURFACE_ONLY to start.
+  // `migration_mode` attribute. This will default to PRE_MIGRATION_SURFACE_ONLY for existing libraries and
+  // NEW_SURFACE_ONLY for new libraries.
   // The allowed values are defined in
   // https://github.com/googleapis/gapic-generator-php/blob/main/src/Utils/MigrationMode.php.
   String getPhpMigrationMode() {
     Map<String, String> phpGapicOverrides = this.overriddenStringAttributes.get(name + "_php_gapic");
-    String migrationMode = "PRE_MIGRATION_SURFACE_ONLY";
-    if (phpGapicOverrides != null && phpGapicOverrides.get("migration_mode") != null) {
+    
+    // If the BUILD.bazel didn't have a php_gapic_library before OR it's a new
+    // BUILD.bazel file altogether, it should be NEW_SURFACE_ONLY. Existing php_gapic_library
+    // targets will use PRE_MIGRATION_SURFACE_ONLY or their existing value.
+    if (phpGapicOverrides == null) {
+      return "NEW_SURFACE_ONLY";
+    }
+
+    String migrationMode = "PRE_MIGRATION_SURFACE_ONLY"; 
+    if (phpGapicOverrides.get("migration_mode") != null) {
       migrationMode = phpGapicOverrides.get("migration_mode");
     }
     return migrationMode;

--- a/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.baseline
+++ b/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.baseline
@@ -245,7 +245,7 @@ php_gapic_library(
     srcs = [":library_proto_with_info"],
     grpc_service_config = "library_example_grpc_service_config.json",
     rest_numeric_enums = True,
-    migration_mode = "PRE_MIGRATION_SURFACE_ONLY",
+    migration_mode = "NEW_SURFACE_ONLY",
     service_yaml = "library_example_v1.yaml",
     transport = "grpc+rest",
     deps = [

--- a/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.updated.baseline
+++ b/bazel/src/test/data/googleapis/google/example/library/v1/BUILD.bazel.updated.baseline
@@ -232,7 +232,7 @@ php_gapic_library(
     name = "library_php_gapic",
     srcs = [":library_proto_with_info"],
     grpc_service_config = "library_example_grpc_service_config.json",
-    migration_mode = "NEW_SURFACE_ONLY",
+    migration_mode = "MIGRATING",
     rest_numeric_enums = True,
     service_yaml = "library_example_v1.yaml",
     transport = "grpc+rest",

--- a/bazel/src/test/data/googleapis/google/example/library/v1legacy/BUILD.bazel.baseline
+++ b/bazel/src/test/data/googleapis/google/example/library/v1legacy/BUILD.bazel.baseline
@@ -235,7 +235,7 @@ php_gapic_library(
     srcs = [":library_proto_with_info"],
     grpc_service_config = "library_example_grpc_service_config.json",
     rest_numeric_enums = True,
-    migration_mode = "PRE_MIGRATION_SURFACE_ONLY",
+    migration_mode = "NEW_SURFACE_ONLY",
     service_yaml = "//google/example/library:library_example_v1.yaml",
     transport = "grpc+rest",
     deps = [

--- a/bazel/src/test/java/com/google/api/codegen/bazel/BuildFileGeneratorTest.java
+++ b/bazel/src/test/java/com/google/api/codegen/bazel/BuildFileGeneratorTest.java
@@ -138,7 +138,7 @@ public class BuildFileGeneratorTest {
     buildozer.batchSetStringAttribute(
         gapicBuildFilePath, "library_go_gapic", "rest_numeric_enums", "Apennines");
     buildozer.batchSetStringAttribute(
-        gapicBuildFilePath, "library_php_gapic", "migration_mode", "NEW_SURFACE_ONLY");
+        gapicBuildFilePath, "library_php_gapic", "migration_mode", "MIGRATING");
 
     // The following values should NOT be preserved:
     buildozer.batchSetStringAttribute(


### PR DESCRIPTION
If the BUILD.bazel didn't have a `php_gapic_library` before OR it's a new BUILD.bazel file altogether, it should be `migration_mode = "NEW_SURFACE_ONLY"`. Existing `php_gapic_library` targets will use `"PRE_MIGRATION_SURFACE_ONLY"` or their existing value.

cc @bshaffer 