### PR TITLE
fix: Avoid emitting an empty string when no list attributes are specified

### DIFF
--- a/bazel/src/main/java/com/google/api/codegen/bazel/ApiVersionedDir.java
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/ApiVersionedDir.java
@@ -540,7 +540,7 @@ class ApiVersionedDir {
             String value = buildozer.getAttribute(file, name, attr);
             if (value != null && value.startsWith("[") && value.endsWith("]")) {
               value = value.substring(1, value.length() - 1);
-              String[] values = value.split(" ");
+              String[] values = value.length() == 0 ? new String[0] : value.split(" ");
               this.overriddenListAttributes.get(name).put(attr, Arrays.asList(values));
             }
           }


### PR DESCRIPTION
This fixes b/290781330 but the same problem exists a few lines earlier; without much experience in this codebase I'm trying to keep this change to an absolute minimum.

Tested by removing the part of the test code which updates an existing value to a new *actual* value - and observing that we end up with `[]` where previously we'd have seen `[""]`.