### PR TITLE
fix(bazel): generate java assembly for type-only

### DIFF
--- a/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.raw_api.mustache
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.raw_api.mustache
@@ -23,7 +23,6 @@ proto_library(
 ##############################################################################
 load(
     "@com_google_googleapis_imports//:imports.bzl",
-    "java_grpc_library",
     "java_proto_library",
 )
 

--- a/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.raw_api.mustache
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.raw_api.mustache
@@ -32,10 +32,13 @@ java_proto_library(
     deps = [":{{name}}_proto"],
 )
 
-java_grpc_library(
-    name = "{{name}}_java_grpc",
-    srcs = [":{{name}}_proto"],
-    deps = [":{{name}}_java_proto"],
+# Open Source Packages
+java_gapic_assembly_gradle_pkg(
+    name = "{{type_only_assembly_name}}-java",
+    deps = [
+        ":{{name}}_proto",
+        ":{{name}}_java_proto",
+    ],
 )
 
 ##############################################################################

--- a/bazel/src/test/data/googleapis/google/example/library/type/BUILD.bazel.baseline
+++ b/bazel/src/test/data/googleapis/google/example/library/type/BUILD.bazel.baseline
@@ -34,10 +34,13 @@ java_proto_library(
     deps = [":types_proto"],
 )
 
-java_grpc_library(
-    name = "types_java_grpc",
-    srcs = [":types_proto"],
-    deps = [":types_java_proto"],
+# Open Source Packages
+java_gapic_assembly_gradle_pkg(
+    name = "library-types-java",
+    deps = [
+        ":types_proto",
+        ":types_java_proto",
+    ],
 )
 
 ##############################################################################

--- a/bazel/src/test/data/googleapis/google/example/library/type/BUILD.bazel.baseline
+++ b/bazel/src/test/data/googleapis/google/example/library/type/BUILD.bazel.baseline
@@ -25,7 +25,6 @@ proto_library(
 ##############################################################################
 load(
     "@com_google_googleapis_imports//:imports.bzl",
-    "java_grpc_library",
     "java_proto_library",
 )
 


### PR DESCRIPTION
For type-only packages (those that don't have any proto `service` definitions), stop generate `java_grpc_library` (no code would be generated anyways) and add `java_gapic_assembly_gradle_pkg` in order to enable publication of the Java classes.

Note: This is implementation is different from the inspiration [CL](http://cl/553855503) in a few ways:
* uses a different, type-only package name (these target names don't really matter when `bazel-bot` only looks for tarball outputs)
* includes the `proto_library` target in the generated output (the inspiration CL did not)

cc: @blakeli0

Part of [b/281092541](http://b/281092541).