### PR TITLE
fix(bazel): type-only csharp assembly pkg

### DIFF
--- a/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.raw_api.mustache
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.raw_api.mustache
@@ -139,7 +139,6 @@ ruby_grpc_library(
 ##############################################################################
 load(
     "@com_google_googleapis_imports//:imports.bzl",
-    "csharp_grpc_library",
     "csharp_proto_library",
 )
 
@@ -148,10 +147,13 @@ csharp_proto_library(
     deps = [":{{name}}_proto"],
 )
 
-csharp_grpc_library(
-    name = "{{name}}_csharp_grpc",
-    srcs = [":{{name}}_proto"],
-    deps = [":{{name}}_csharp_proto"],
+# Open Source Packages
+csharp_gapic_assembly_pkg(
+    name = "{{type_only_assembly_name}}-csharp",
+    generate_nongapic_package = True,
+    deps = [
+        ":{{name}}_csharp_proto",
+    ],
 )
 
 ##############################################################################

--- a/bazel/src/test/data/googleapis/google/example/library/type/BUILD.bazel.baseline
+++ b/bazel/src/test/data/googleapis/google/example/library/type/BUILD.bazel.baseline
@@ -143,7 +143,6 @@ ruby_grpc_library(
 ##############################################################################
 load(
     "@com_google_googleapis_imports//:imports.bzl",
-    "csharp_grpc_library",
     "csharp_proto_library",
 )
 
@@ -152,10 +151,13 @@ csharp_proto_library(
     deps = [":types_proto"],
 )
 
-csharp_grpc_library(
-    name = "types_csharp_grpc",
-    srcs = [":types_proto"],
-    deps = [":types_csharp_proto"],
+# Open Source Packages
+csharp_gapic_assembly_pkg(
+    name = "library-types-csharp",
+    generate_nongapic_package = True,
+    deps = [
+        ":types_csharp_proto",
+    ],
 )
 
 ##############################################################################

--- a/bazel/src/test/data/googleapis/google/example/library/type/BUILD.bazel.baseline
+++ b/bazel/src/test/data/googleapis/google/example/library/type/BUILD.bazel.baseline
@@ -155,7 +155,7 @@ csharp_proto_library(
 
 # Open Source Packages
 csharp_gapic_assembly_pkg(
-    name = "library-types-csharp",
+    name = "google-example-library-types-csharp",
     generate_nongapic_package = True,
     deps = [
         ":types_csharp_proto",


### PR DESCRIPTION
Adds `assmebly_pkg` target generation for type-only packages (those that do not have any proto `service` definitions within), and stops including the `csharp_grpc_library` target since there is no gRPC code to generate without a `service`.

Part of [b/281092541](http://b/281092541).