### PR TITLE
fix(bazel): use entire proto pkg for type assembly name

### DIFF
--- a/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
@@ -106,7 +106,7 @@ class BazelBuildFileView {
     // simple proto type directory with no API definitions.
     boolean isGapicLibrary = !bp.getServices().isEmpty();
     if (!isGapicLibrary) {
-      tokens.put("type_only_assembly_name", typeOnlyAssemblyName(bp.getProtoPackage()));
+      tokens.put("type_only_assembly_name", bp.getProtoPackage().replaceAll("\\.", "-"));
       return;
     }
 
@@ -492,20 +492,6 @@ class BazelBuildFileView {
       }
     }
     return pyImports;
-  }
-
-  // Simply take the last two segments of the package to use as the assembly name.
-  public static String typeOnlyAssemblyName(String pkg) {
-    String[] parts = pkg.split("\\.");
-    if (parts.length < 2) {
-      return pkg;
-    }
-
-    // google.type --> google-type
-    // google.cloud.foo.type --> foo-type
-    int last = parts.length - 1;
-    int penultimate = parts.length - 2;
-    return parts[penultimate]+"-"+parts[last];
   }
 
   Map<String, String> getTokens() {

--- a/bazel/src/test/data/googleapis/google/example/library/type/BUILD.bazel.baseline
+++ b/bazel/src/test/data/googleapis/google/example/library/type/BUILD.bazel.baseline
@@ -35,7 +35,7 @@ java_proto_library(
 
 # Open Source Packages
 java_gapic_assembly_gradle_pkg(
-    name = "library-types-java",
+    name = "google-example-library-types-java",
     deps = [
         ":types_proto",
         ":types_java_proto",
@@ -62,7 +62,7 @@ go_proto_library(
 )
 
 go_gapic_assembly_pkg(
-    name = "library-types-go",
+    name = "google-example-library-types-go",
     deps = [
         ":types_go_proto",
     ],
@@ -114,7 +114,7 @@ php_proto_library(
 )
 
 php_gapic_assembly_pkg(
-    name = "library-types-php",
+    name = "google-example-library-types-php",
     deps = [
         ":types_php_proto",
     ],

--- a/bazel/src/test/java/com/google/api/codegen/bazel/BazelBuildFileViewTest.java
+++ b/bazel/src/test/java/com/google/api/codegen/bazel/BazelBuildFileViewTest.java
@@ -35,20 +35,4 @@ public class BazelBuildFileViewTest {
     actual = BazelBuildFileView.assembleGoImportPath(true, "google.cloud.foo.v1", "cloud.google.com/go/foo/apiv1/foopb;foopb");
     Assert.assertEquals("cloud.google.com/go/foo/apiv1;foo", actual);
   }
-
-  @Test
-  public void testTypeOnlyAssemblyName() {
-    List<List<String>> tests = Arrays.asList(
-      Arrays.asList("type", "type"),  
-      Arrays.asList("google.type", "google-type"),
-      Arrays.asList("google.geo.type", "geo-type")
-    );
-    for (List<String> testCase : tests) {
-      String pkg = testCase.get(0);
-      String want = testCase.get(1);
-
-      String got = BazelBuildFileView.typeOnlyAssemblyName(pkg);
-      Assert.assertEquals(want, got);
-    }
-  }
 }


### PR DESCRIPTION
Changes the generated name for type-only assembly_pkg targets to be converted directly from the entire proto package instead of just the last two segments. It aligns better with the naming of GAPIC assembly_pkg targets, and the target names only really matter for debugging b.c bazel-bot just runs everything and captures the resulting tarballs.

Based on discussion in https://github.com/googleapis/rules_gapic/pull/169#discussion_r1284790467