### PR TITLE
fix(bazel): missing loads in type-only template

### DIFF
--- a/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.raw_api.mustache
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.raw_api.mustache
@@ -24,6 +24,7 @@ proto_library(
 load(
     "@com_google_googleapis_imports//:imports.bzl",
     "java_proto_library",
+    "java_gapic_assembly_gradle_pkg",
 )
 
 java_proto_library(
@@ -142,6 +143,7 @@ ruby_grpc_library(
 load(
     "@com_google_googleapis_imports//:imports.bzl",
     "csharp_proto_library",
+    "csharp_gapic_assembly_pkg",
 )
 
 csharp_proto_library(

--- a/bazel/src/test/data/googleapis/google/example/library/type/BUILD.bazel.baseline
+++ b/bazel/src/test/data/googleapis/google/example/library/type/BUILD.bazel.baseline
@@ -26,6 +26,7 @@ proto_library(
 load(
     "@com_google_googleapis_imports//:imports.bzl",
     "java_proto_library",
+    "java_gapic_assembly_gradle_pkg",
 )
 
 java_proto_library(
@@ -146,6 +147,7 @@ ruby_grpc_library(
 load(
     "@com_google_googleapis_imports//:imports.bzl",
     "csharp_proto_library",
+    "csharp_gapic_assembly_pkg",
 )
 
 csharp_proto_library(


### PR DESCRIPTION
Fixes missing load statements for the type-only template.

I always miss these, I think we need to devise a test for it...