### PR TITLE
fix(bazel): include package_name for type-only csharp

### DIFF
--- a/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.raw_api.mustache
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.raw_api.mustache
@@ -154,6 +154,7 @@ csharp_proto_library(
 # Open Source Packages
 csharp_gapic_assembly_pkg(
     name = "{{type_only_assembly_name}}-csharp",
+    package_name = "{{csharp_namespace}}",
     generate_nongapic_package = True,
     deps = [
         ":{{name}}_csharp_proto",

--- a/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
@@ -107,6 +107,7 @@ class BazelBuildFileView {
     boolean isGapicLibrary = !bp.getServices().isEmpty();
     if (!isGapicLibrary) {
       tokens.put("type_only_assembly_name", bp.getProtoPackage().replaceAll("\\.", "-"));
+      tokens.put("csharp_namespace", bp.getLangProtoPackages().get("csharp"));
       return;
     }
 

--- a/bazel/src/test/data/googleapis/google/example/library/type/BUILD.bazel.baseline
+++ b/bazel/src/test/data/googleapis/google/example/library/type/BUILD.bazel.baseline
@@ -158,6 +158,7 @@ csharp_proto_library(
 # Open Source Packages
 csharp_gapic_assembly_pkg(
     name = "google-example-library-types-csharp",
+    package_name = "Google.Example.Library.Types",
     generate_nongapic_package = True,
     deps = [
         ":types_csharp_proto",

--- a/bazel/src/test/data/googleapis/google/example/library/type/library_types.proto
+++ b/bazel/src/test/data/googleapis/google/example/library/type/library_types.proto
@@ -25,6 +25,7 @@ option go_package = "google.golang.org/genproto/googleapis/example/library/types
 option java_multiple_files = true;
 option java_outer_classname = "LibraryTypesProto";
 option java_package = "com.google.example.library.types";
+option csharp_namespace = "Google.Example.Library.Types";
 
 // A Shelf contains a collection of books with a theme.
 message Shelf {


### PR DESCRIPTION
Include `package_name` in type-only `csharp_gapic_assembly_pkg` target. Derived from the `csharp_namespace` annotation.