### PR TITLE
fix(bazel): throw RuntimeExceptions, including missing chsarp_namespace

### DIFF
--- a/bazel/src/main/java/com/google/api/codegen/bazel/ApisVisitor.java
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/ApisVisitor.java
@@ -190,12 +190,8 @@ class ApisVisitor extends SimpleFileVisitor<Path> {
 
     System.out.println(
         "Write File [" + tmplType + "]: " + outDir.toString() + File.separator + "BUILD.bazel");
-    try {
-      BazelBuildFileView bpv = new BazelBuildFileView(bp, transport, numericEnums);
-      fileWriter.write(outFilePath, template.expand(bpv));
-    } catch (RuntimeException ex) {
-      ex.printStackTrace();
-    }
+    BazelBuildFileView bpv = new BazelBuildFileView(bp, transport, numericEnums);
+    fileWriter.write(outFilePath, template.expand(bpv));
 
     return FileVisitResult.CONTINUE;
   }

--- a/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileView.java
@@ -107,6 +107,9 @@ class BazelBuildFileView {
     boolean isGapicLibrary = !bp.getServices().isEmpty();
     if (!isGapicLibrary) {
       tokens.put("type_only_assembly_name", bp.getProtoPackage().replaceAll("\\.", "-"));
+      if (!bp.getLangProtoPackages().containsKey("csharp")) {
+        throw new RuntimeException("Missing required option chsarp_namespace: https://google.aip.dev/191#packaging-annotations");
+      }
       tokens.put("csharp_namespace", bp.getLangProtoPackages().get("csharp"));
       return;
     }


### PR DESCRIPTION
Throw an exception when the `option csharp_namespace` is missing for a type-only proto. This also removes the code that "silenced" `RuntimeException` s so that generation actually fails when they are encountered.

The alternative is to silently allow a value like `"{{csharp_namespace}}"` to be generated, which would pass the build when it shouldn't.