### PR TITLE
feat(bazel): python type-only gapic assembly targets

### DIFF
--- a/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.raw_api.mustache
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.raw_api.mustache
@@ -107,7 +107,7 @@ py_gapic_library(
 
 # Open Source Packages
 py_gapic_assembly_pkg(
-    name = "{{type_only_assembly_name}}",
+    name = "{{type_only_assembly_name}}-py",
     deps = [
         ":{{name}}_py_gapic",
     ],

--- a/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.raw_api.mustache
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/BUILD.bazel.raw_api.mustache
@@ -75,6 +75,8 @@ load(
     "moved_proto_library",
     "py_grpc_library",
     "py_proto_library",
+    "py_gapic_library",
+    "py_gapic_assembly_pkg",
 )
 
 moved_proto_library(
@@ -94,6 +96,21 @@ py_grpc_library(
     name = "{{name}}_py_grpc",
     srcs = [":{{name}}_moved_proto"],
     deps = [":{{name}}_py_proto"],
+)
+
+py_gapic_library(
+    name = "{{name}}_py_gapic",
+    srcs = [":{{name}}_proto"],
+    rest_numeric_enums = False,
+    transport = "grpc+rest",
+)
+
+# Open Source Packages
+py_gapic_assembly_pkg(
+    name = "{{type_only_assembly_name}}",
+    deps = [
+        ":{{name}}_py_gapic",
+    ],
 )
 
 ##############################################################################

--- a/bazel/src/test/data/googleapis/google/example/library/type/BUILD.bazel.baseline
+++ b/bazel/src/test/data/googleapis/google/example/library/type/BUILD.bazel.baseline
@@ -77,6 +77,8 @@ load(
     "moved_proto_library",
     "py_grpc_library",
     "py_proto_library",
+    "py_gapic_library",
+    "py_gapic_assembly_pkg",
 )
 
 moved_proto_library(
@@ -98,6 +100,21 @@ py_grpc_library(
     name = "types_py_grpc",
     srcs = [":types_moved_proto"],
     deps = [":types_py_proto"],
+)
+
+py_gapic_library(
+    name = "types_py_gapic",
+    srcs = [":types_proto"],
+    rest_numeric_enums = False,
+    transport = "grpc+rest",
+)
+
+# Open Source Packages
+py_gapic_assembly_pkg(
+    name = "google-example-library-types",
+    deps = [
+        ":types_py_gapic",
+    ],
 )
 
 ##############################################################################

--- a/bazel/src/test/data/googleapis/google/example/library/type/BUILD.bazel.baseline
+++ b/bazel/src/test/data/googleapis/google/example/library/type/BUILD.bazel.baseline
@@ -111,7 +111,7 @@ py_gapic_library(
 
 # Open Source Packages
 py_gapic_assembly_pkg(
-    name = "google-example-library-types",
+    name = "google-example-library-types-py",
     deps = [
         ":types_py_gapic",
     ],


### PR DESCRIPTION
Adds generation of Python gapic and assmebly package targets for type-only packages. The former creates the proto-plus wrapper types, the latter produces the archived code for (Bazel | Owl)Bot integration.

Fixes http://b/297530684. Tested on googleapis already.