### PR TITLE
fix(bazel):  avoid potential null dereference

### DIFF
--- a/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileTemplate.java
+++ b/bazel/src/main/java/com/google/api/codegen/bazel/BazelBuildFileTemplate.java
@@ -84,7 +84,7 @@ class BazelBuildFileTemplate {
       String kind = entry.getKey();
       String newName = entry.getValue();
       String currentName = buildozer.getAttribute(buildBazelPath, "%" + kind, "name");
-      if (!currentName.equals(newName)) {
+      if (!newName.equals(currentName)) {
         buildozer.batchSetStringAttribute(buildBazelPath, currentName, "name", newName);
       }
     }


### PR DESCRIPTION
##### Motivation:

In file: BazelBuildFileTemplate.java, class: BazelBuildFileTemplate, there is a method expand that, there is a potential Null pointer dereference while calling the equals method. Which can raise a NullPointerException..

##### Potential Null Dereference Path:

In method `String expand(BazelBuildFileView bpv)`

```java
String newName = entry.getValue();
String currentName = buildozer.getAttribute(buildBazelPath, "%" + kind, "name");
```

The variable currentName can be null as the implementation getAttribute()
```java
}

  // Get the value of the given attribute of the given target
  public String getAttribute(Path bazelBuildFile, String target, String attribute)
      throws IOException {
    List<String> executeResult;
    try {
      executeResult = execute(bazelBuildFile, String.format("print %s", attribute), target);
      String value = executeResult.get(0);
      if (value.equals("(missing)")) {
        return null;
      }
      // if value has spaces, `buildozer print` will return it in quotes. Remove the quotes
      if (value.charAt(0) == '"' && value.charAt(value.length() - 1) == '"') {
        value = value.substring(1, value.length() - 1);
      }
      return value;
    } catch (IndexOutOfBoundsException ignored) {
      return null;
    }
  }
```
Now, if this variable is null then 
```java
if (!currentName.equals(newName)) {
    buildozer.batchSetStringAttribute(buildBazelPath, currentName, "name", newName);
}
```
The argument passed to the equals method is not null which triggers a `NullPointerException`.

##### Fix:
Instead, pass the possible null value to the method argument
```java
if (!newName.equals(currentName)) {
    buildozer.batchSetStringAttribute(buildBazelPath, currentName, "name", newName);
}
```

##### Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.